### PR TITLE
Added assets demo url based on environment

### DIFF
--- a/templates/ignite-ui-template/styles/stackblitz-handler.js
+++ b/templates/ignite-ui-template/styles/stackblitz-handler.js
@@ -51,7 +51,7 @@
         var assetsUrl = demosBaseUrl + assetsFolder;
         for (var i = 0; i < files.length; i++) {
             if (files[i].hasRelativeAssetsUrls) {
-                files[i].content = files[i].content.replace(assetsRegex, "https://www.infragistics.com/angular-demos/assets/");
+                files[i].content = files[i].content.replace(assetsRegex, assetsUrl);
             }
         }
     }


### PR DESCRIPTION
Closes #168.

This PR will break the following functionality: loading stackblitz demos locally will have assets resources not loading because of the HTTP protocol we use in development environment.