### PR TITLE
IE 11 left menu missing and SB samples not opening

### DIFF
--- a/templates/ignite-ui-template/styles/docfx.js
+++ b/templates/ignite-ui-template/styles/docfx.js
@@ -104,7 +104,7 @@ $(function() {
   }
 
   // Set note blocks titles
-  async function renderNoteBlocks() {
+  function renderNoteBlocks() {
     var title, newHeaderElement;
 
     $(".alert").each(function(i) {

--- a/web.config
+++ b/web.config
@@ -4,5 +4,10 @@
         <staticContent>
             <mimeMap fileExtension=".json" mimeType="application/json;charset=UTF-8;" />
         </staticContent>
+        <httpProtocol>
+            <customHeaders>
+                <add name="X-XSS-Protection" value="0" />
+            </customHeaders>
+        </httpProtocol>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
Closes #271.
Regarding the issue with StackBlitz not opening from IE 11 (we experience this in IE 11 on prod on all samples):

![capture](https://user-images.githubusercontent.com/6439482/38937180-4595b4f4-432b-11e8-810f-dfdbfcc3d3c1.PNG)

I am not able to reproduce it on staging, no clue why.

I am reproducing it locally if igniteui-samples and igniteui-docfx have different domains. The issue appears to be that we are getting content from samples (.json files) via AJAX and sending the same content to a third-party (StackBlitz) - this is detected as a XSS from IE 11.

Anyway, disabling XSS via X-XSS-Protection header is the proposed solution all over the net so we can go with it if you decide.

If you need, please perform further tests.