### PR TITLE
Edits for Chip topic and TOC

### DIFF
--- a/jp/components/chip.md
+++ b/jp/components/chip.md
@@ -119,11 +119,11 @@ public chipsOrderChanged(event) {
 
 #### Chip テンプレート
 
-`IgxChipComponent` の構造は主にチップのコンテンツ、削除ボタン、prefix、suffix、`connector` です。削除ボタン以外の要素をテンプレート化できます。
+`IgxChipComponent` の構造は主にチップのコンテンツ、削除ボタン、`prefix`、`suffix`、`connector` です。削除ボタン以外の要素をテンプレート化できます。
 
 チップのコンテンツは、チップの `prefix`、`suffix`、または `connector` を定義する要素以外のテンプレートに定義されるコンテンツです。コンテンツは任意のタイプを定義できます。
 
-`prefix` および `suffix` は実際のチップ領域にある要素で、テンプレート化できます。テンプレートを指定するには、IgxPrefix および IgxSuffix ディレクティブを使用します。
+`prefix` および `suffix` は実際のチップ領域にある要素で、テンプレート化できます。テンプレートを指定するには、`IgxPrefix` および `IgxSuffix` ディレクティブを使用します。
 以下は、`prefix` にアイコン、`label` にテキスト、`suffix` にカスタム アイコン ボタンを使用した例です。
 
 ```html
@@ -163,7 +163,7 @@ public chipsOrderChanged(event) {
 - チップがフォーカスされた場合のキーボード コントロール:
 
   - <kbd>LEFT</kbd> - 左側にあるチップをフォーカスします。
-  - <kbd>RIGTH</kbd> - 右側にあるチップをフォーカスします。
+  - <kbd>RIGHT</kbd> - 右側にあるチップをフォーカスします。
   - <kbd>SPACE</kbd> - チップが選択可能な場合、選択状態を切り替えます。
   - <kbd>DELETE</kbd> - チップの削除を手動的に処理するために `onRemove` 出力を発生します。
   - <kbd>SHIFT</kbd> + <kbd>LEFT</kbd> - フォーカスされたチップの位置を 1 つ左に移動します。
@@ -178,5 +178,5 @@ public chipsOrderChanged(event) {
 <div class="divider--half"></div>
 コミュニティに参加して新しいアイデアをご提案ください。
 
-- [Ignite UI for Angular **フォーカス** (英語)](https://www.infragistics.com/community/forums/f/ignite-ui-for-angular)
+- [Ignite UI for Angular **フォーラム** (英語)](https://www.infragistics.com/community/forums/f/ignite-ui-for-angular)
 - [Ignite UI for Angular **GitHub** (英語)](https://github.com/IgniteUI/igniteui-angular)

--- a/jp/components/chip.md
+++ b/jp/components/chip.md
@@ -2,6 +2,7 @@
 title: Chip コンポーネント - ネイティブ Angular | Ignite UI for Angular
 _description: Ignite UI for Angular Chip コンポーネントは入力、属性、または操作を表す小さい要素を提供します。
 _keywords: ジェット, Angular, ネイティブ Angular コンポーネント スイート, ネイティブ Angular コントロール, ネイティブ Angular コンポーネント ライブラリ, ネイティブ Angular コンポーネント, Chip, Chip コンポーネント, ChipArea, ChipArea コンポーネント
+_language: ja
 ---
 
 ### Chip

--- a/jp/components/combo.md
+++ b/jp/components/combo.md
@@ -229,7 +229,7 @@ Template Forms:
     <iframe id="input-group-sample-6-sample" frameborder="0" seamless width="100%" height="100%" src="{environment:demosBaseUrl}/input-group-sample-6" onload="onSampleIframeContentLoaded(this);"></iframe>
 </div>
 <div>
-    <button data-localize="stackblitz" class="stackblitz-btn" data-iframe-id="input-group-sample-6-sample" data-demos-base-url="{environment:demosBaseUrl}">view on stackblitz</button>
+    <button data-localize="stackblitz" class="stackblitz-btn" data-iframe-id="input-group-sample-6-sample" data-demos-base-url="{environment:demosBaseUrl}">StackBlitz で開く</button>
 </div>
 <div class="divider--half"></div>
 
@@ -240,7 +240,7 @@ Reactive Forms:
     <iframe id="reactive-forms-sample" frameborder="0" seamless width="100%" height="100%" src="{environment:demosBaseUrl}/reactive-forms" onload="onSampleIframeContentLoaded(this);"></iframe>
 </div>
 <div>
-    <button data-localize="stackblitz" class="stackblitz-btn" data-iframe-id="reactive-forms-sample" data-demos-base-url="{environment:demosBaseUrl}">view on stackblitz</button>
+    <button data-localize="stackblitz" class="stackblitz-btn" data-iframe-id="reactive-forms-sample" data-demos-base-url="{environment:demosBaseUrl}">StackBlitz で開く</button>
 </div>
 <div class="divider--half"></div>
 

--- a/jp/components/overlay_main.md
+++ b/jp/components/overlay_main.md
@@ -7,7 +7,7 @@ _language: ja
 
 ## Overlay の概要
 <p class="highlight">
-The `IgxOverlayService` は、`IgxToggle` ディレクティブに完全に統合されています。toggle ディレクティブを使用する場合、`overlaySettings` パラメーターを toggle の toggle の `toggle()` メソッドに設定してコンテンツが描画された場合の切り替え方法を変更できます。
+`IgxOverlayService` は、`IgxToggle` ディレクティブに完全に統合されています。toggle ディレクティブを使用する場合、`overlaySettings` パラメーターを toggle の toggle の `toggle()` メソッドに設定してコンテンツが描画された場合の切り替え方法を変更できます。
 </p>
 <div class="divider--half"></div>
 

--- a/jp/components/toc.yml
+++ b/jp/components/toc.yml
@@ -155,7 +155,7 @@
   href: circular_progress.md
 - name: Virtual For Directive
   href: for_of.md
-- name: チップ
+- name: Chip
   href: chip.md
   new: true
 - name: インタラクション


### PR DESCRIPTION
Added some backticks for code words.  Fixed spelling.  Untranslated the topic name because it is a control name and we leave those in English.