### PR TITLE
Topic - Grid - Update rowSelection API section and add doc links

### DIFF
--- a/en/components/grid_selection.md
+++ b/en/components/grid_selection.md
@@ -23,7 +23,7 @@ With row selection in Ignite UI for Angular, there is a checkbox that precedes a
 
 #### Single Selection
 
-The grid single selection can be easily setup using the grid's `onSelection` event. The event emits a reference to the cell component. That cell component has a reference to the row component that is holding it. The row component reference `rowID` getter can be used to pass a unique identifier for the row (using either `rowData[primaryKey]` or the `rowData` object itself) to the appropriate list of the selectionAPI. To make sure that only a single row is always selected, we empty the `selectionAPI` row selection list beforehand (the second argument in the `selectRows` method call):
+The grid single selection can be easily setup using the grid's [`onSelection`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#onselection) event. The event emits a reference to the cell component. That cell component has a reference to the row component that is holding it. The row component reference [`rowID`](https://www.infragistics.com/products/ignite-ui-angular/docs/typescript/classes/igxgridrowcomponent.html#rowid) getter can be used to pass a unique identifier for the row (using either [`rowData[primaryKey]`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#primarykey) or the [`rowData`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridrowcomponent.html#rowdata) object itself) to the appropriate list of the selectionAPI. To make sure that only a single row is always selected, we empty the [`selectionAPI`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxselectionapiservice.html) row selection list beforehand (the second argument in the [`selectRows`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#selectrows) method call):
 
 ```html
     <!-- in example.component.html -->
@@ -47,36 +47,21 @@ The grid single selection can be easily setup using the grid's `onSelection` eve
 
 #### Multiple Selection
 
-To enable multiple row selection, the `igx-grid` exposes the `rowSelectable` property. Setting `rowSelectable` to `true` enables a select checkbox field on each row and in the grid header. The checkbox allows users to select multiple rows, with the selection persisting through scrolling, paging, and data operations such as sorting and filtering:
+To enable multiple row selection, the [`igx-grid`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html) exposes the [`rowSelectable`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#rowselectable) property. Setting `rowSelectable` to `true` enables a select checkbox field on each row and in the grid header. The checkbox allows users to select multiple rows, with the selection persisting through scrolling, paging, and data operations such as sorting and filtering:
 
 ```html
     <igx-grid #grid1 [data]="remote | async" [primaryKey]="'ProductID'" [rowSelectable]="selection" (onSelection)="handleRowSelection($event)"
       [width]="'800px'" [height]="'600px'">
 ```
 
-*Note:* In order to have proper row selection and cell selection, while grid has remote virtualization, `primaryKey` should be provided.
-*Note:* When grid has remote virtualization then clicking the header checkox will select/deselect all records. But when all records are selected through header checkbox and then a visible row has been deselected, when new data is loaded in the grid on demand, it is a limitation that the newly loaded rows are not selected.
+**Note:** In order to have proper row selection and cell selection, while grid has remote virtualization, [`primaryKey`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#primarykey) should be provided.
 
-### Methods
+**Note:** If filtering is in place, [`selectAllRows()`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#selectallrows) and [`deselectAllRows()`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#deselectallrows) select/deselect all *filtered* rows.
 
-#### IgxGridComponent
 
-   | Name     | Description                | Return type                                       | Parameters           |
-   |----------|----------------------------|---------------------------------------------------|----------------------|
-   | selectedRows | Get current selection state    | `Array<any>`- array with selected rows' ID (primaryKey or rowData)| |
-   | selectRows   | Select specified rows by ID      | `void`- does not return anything | `Array<any>`, clearCurrentSelection: `boolean`    |
-   | deselectRows | Deselect specified rows by ID    | `void`- does not return anything | `Array<any>` |
-   | selectAllRows | Select all rows            | `void`- does not return anything |    N/A                    |
-   | deselectAllRows | Select all rows          | `void`- does not return anything |    N/A                    |
+**Note:** When grid has remote virtualization then clicking the header checkox will select/deselect all records. But when all records are selected through header checkbox and then a visible row has been deselected, when new data is loaded in the grid on demand, it is a limitation that the newly loaded rows are not selected.
 
-*Note:* If filtering is in place, `selectAllRows()` and `deselectAllRows()` select/deselect all *filtered* rows.
-
-### Events
-|Name|Description|Parameters|
-|--|--|--|
-| onRowSelectionChange | Emitted when selection is changing. | { selection: `Array<any>`, row: IgxRowComponent, rowID: any|
-
-*Note:* Cell selection will trigger onSelection and not onRowSelection.
+**Note:** Cell selection will trigger [`onSelection`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#onselection) and not [`onRowSelectionChange`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#onrowselectionchange).
 
 ### Code Snippets
 
@@ -108,6 +93,13 @@ public handleRowSelectionChange(args) {
     args.checked = false; // overwrites the checkbox state
 }
 ```
+### API Reference
+* [IgxGridComponent API]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html)
+* [IgxGridRowComponent API]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridrowcomponent.html)
+* [IgxGridCellComponent API]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcellcomponent.html)
+* [IgxSelectionAPIService]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxselectionapiservice.html)
+
+* [IgxGridComponent Styles]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/sass/index.html#themes-mixin-igx-grid)
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/jp/components/grid_selection.md
+++ b/jp/components/grid_selection.md
@@ -24,7 +24,7 @@ Ignite UI for Angular 行選択は、行内のすべての列の前に描画さ�
 
 #### 単一選択
 
-グリッドの単一選択を grid の `onSelection` イベントで構成できます。イベントはセル コンポーネントへの参照を発行します。イベントはセル コンポーネントへの参照を発行し、そのセルコンポーネントは含まれる行コンポーネントへの参照を含みます。行コンポーネント参照の `rowID` ゲッターを使用して、`rowData[primaryKey]` または `rowData` オブジェクト自身を使用して行の一意識別子を selectionAPI の適切なリストに渡します。単一行のみを選択させるには、`selectionAPI` 行選択リストを空にします。これは `selectRows` メソッドの呼び出しの 2 番目の引数です。
+グリッドの単一選択を grid の [`onSelection`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#onselection) イベントで構成できます。イベントはセル コンポーネントへの参照を発行します。イベントはセル コンポーネントへの参照を発行し、そのセルコンポーネントは含まれる行コンポーネントへの参照を含みます。行コンポーネント参照の [`rowID`](https://www.infragistics.com/products/ignite-ui-angular/docs/typescript/classes/igxgridrowcomponent.html#rowid) ゲッターを使用して、[`rowData[primaryKey]`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#primarykey) または [`rowData`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridrowcomponent.html#rowdata) オブジェクト自身を使用して行の一意識別子を selectionAPI の適切なリストに渡します。単一行のみを選択させるには、[`selectionAPI`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxselectionapiservice.html) 行選択リストを空にします。これは [`selectRows`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#selectrows) メソッドの呼び出しの 2 番目の引数です。
 
 ```html
     <!-- in example.component.html -->
@@ -48,37 +48,20 @@ Ignite UI for Angular 行選択は、行内のすべての列の前に描画さ�
 
 #### 複数選択
 
-複数行選択を有効にするには、`igx-grid` の `rowSelectable` プロパティを使用します。`rowSelectable` を `true` に設定すると、各行およびグリッド ヘッダーで選択チェックボックス フィールドが有効になります。チェックボックスを使用して複数行を選択でき、スクロール、ページング、および並べ替えとフィルターなどのデータ操作で選択が保持されます。
+複数行選択を有効にするには、[`igx-grid`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html) の [`rowSelectable`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#rowselectable) プロパティを使用します。`rowSelectable` を `true` に設定すると、各行およびグリッド ヘッダーで選択チェックボックス フィールドが有効になります。チェックボックスを使用して複数行を選択でき、スクロール、ページング、および並べ替えとフィルターなどのデータ操作で選択が保持されます。
 
 ```html
     <igx-grid #grid1 [data]="remote | async" [primaryKey]="'ProductID'" [rowSelectable]="selection" (onSelection)="handleRowSelection($event)"
       [width]="'800px'" [height]="'600px'">
 ```
 
-**注**: グリッドにリモート仮想化がある場合に行選択およびセル選択が正しく動作するには、`primaryKey` を設定します。
+**注**: グリッドにリモート仮想化がある場合に行選択およびセル選択が正しく動作するには、[`primaryKey`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#primarykey) を設定します。
 
 **注**: グリッドでリモート仮想化が有効な場合、ヘッダー チェックボックスをクリックすると、すべてのレコードを選択/選択解除できます。すべてのレコードをヘッダー チェックボックスで選択した後に表示行の選択が解除された場合、オンデマンドでグリッドに新しいデータを読み込んだ際に新しく読み込んだ行が選択されない機能制限があります。
 
-### メソッド
+**注**: フィルタリング機能が有効にされる場合、[`selectAllRows()`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#selectallrows) および [`deselectAllRows()`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#deselectallrows) は**フィルターされた行**のみを選択/選択解除します。
 
-#### IgxGridComponent
-
-| 名前     | 説明                | 戻り型                                       | パラメーター           |
-|----------|----------------------------|---------------------------------------------------|----------------------|
-| selectedRows | 現在の選択状態を取得します。    | `Array<any>`- 選択済み行の ID (primaryKey または rowData) を持つ配列| |
-| selectRows   | 指定した行を ID によって選択します。      | `void`- 何も返しません。 | `Array<any>`, clearCurrentSelection: `boolean`    |   
-| deselectRows | 指定した行を ID によって選択解除します。    | `void`- 何も返しません。 | `Array<any>` |
-| selectAllRows | すべての行を選択します。            | `void`- 何も返しません。 |    N/A                    |
-| deselectAllRows | すべての行を選択解除します。         | `void`- 何も返しません。 |    N/A                    |
-
-**注**: フィルタリング機能が有効にされる場合、`selectAllRows()` および `deselectAllRows()` は**フィルターされた行**のみを選択/選択解除します。
-
-### イベント
-|名前|説明|パラメーター|
-|--|--|--|
-| onRowSelectionChange | 選択が変更されているときに発生します。 | { selection: `Array<any>`, row: IgxRowComponent, rowID: any|
-
-**注**: セル選択は onSelection をトリガーしますが、onRowSelection をトリガーしません。
+**注**: セル選択は [`onSelection`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#onselection) をトリガーしますが、[`onRowSelectionChange`]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html#onrowselectionchange) をトリガーしません。
 
 ### コード スニペット
 
@@ -115,6 +98,13 @@ public handleRowSelectionChange(args) {
     args.checked = false; // overwrites the checkbox state
 }
 ```
+### API Reference
+* [IgxGridComponent API]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcomponent.html)
+* [IgxGridRowComponent API]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridrowcomponent.html)
+* [IgxGridCellComponent API]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxgridcellcomponent.html)
+* [IgxSelectionAPIService]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/typescript/classes/igxselectionapiservice.html)
+
+* [IgxGridComponent Styles]({environment:infragisticsBaseUrl}/products/ignite-ui-angular/docs/sass/index.html#themes-mixin-igx-grid)
 
 ### 追加のリソース
 <div class="divider--half"></div>


### PR DESCRIPTION
Related to the new way API is supposed to be displayed in docfx topics:

Added API doc links to code snippets in the topic
Added API reference section at the bottom of the article
Remove API tables