### PR TITLE
Configuring Typedoc and Sassdoc references in topics.

### DIFF
--- a/en/components/grid_editing.md
+++ b/en/components/grid_editing.md
@@ -21,10 +21,10 @@ The Grid component in Ignite UI for Angular provides you a default cell template
 
 In order to be able to enter edit mode for specific cell, you should first set the column to be [`editable`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#editable). If you want to use a data type specific *edit templates*, you should specify the column [`dataType`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#datatype) property. So let's now see what are the default templates for each type:
 
- - For `string` data type, default template is using **igxInput**
- - For `number` data type, default template is using **igxInput type="number"**, so if you try to update cell to a value which can not be parsed to a number your change is going to be discarded, and the value in the cell will be set to **0**.
- - For `date` data type, default template is using **igx-date-picker**
- - For `boolean` data type, default template is using **igx-checkbox**
+ - For `string` data type, default template is using [**igxInput**]({environment:angularApiUrl}/classes/igxinputdirective.html)
+ - For `number` data type, default template is using **[igxInput]({environment:angularApiUrl}/classes/igxinputdirective.html) type="number"**, so if you try to update cell to a value which can not be parsed to a number your change is going to be discarded, and the value in the cell will be set to **0**.
+ - For `date` data type, default template is using [**igx-date-picker**]({environment:angularApiUrl}/classes/igxdatepickercomponent.html)
+ - For `boolean` data type, default template is using [**igx-checkbox**]({environment:angularApiUrl}/classes/igxcheckboxcomponent.html)
 
 You can enter edit mode for specific cell, when an editable cell is focused in one of the following ways:
  - on double click;
@@ -128,7 +128,14 @@ These can be wired to user interactions, not necessarily related to the **igx-gr
 
 ### API
 * [IgxGridCellComponent]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 * [IgxGridRowComponent]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
+* [IgxInputDirective]({environment:angularApiUrl}/classes/igxinputdirective.html)
+* [IgxDatePickerComponent]({environment:angularApiUrl}/classes/igxdatepickercomponent.html)
+* [IgxDatePickerComponent Styles]({environment:sassApiUrl}/index.html#function-igx-date-picker-theme)
+* [IgxCheckboxComponent]({environment:angularApiUrl}/classes/igxcheckboxcomponent.html)
+* [IgxCheckboxComponent Styles]({environment:sassApiUrl}/index.html#function-igx-checkbox-theme) 
+
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/en/components/grid_multi_column_headers.md
+++ b/en/components/grid_multi_column_headers.md
@@ -6,7 +6,7 @@ _keywords: Ignite UI for Angular, UI controls, Angular widgets, web widgets, UI 
 
 ## Multi Column Headers
 
-`igxGrid` supports `multi-column headers` which allows you to group columns by placing them under a common header. Every `column group` could be a representation of combinations between other groups or columns.
+[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) supports `multi-column headers` which allows you to group columns by placing them under a common header. Every `column group` could be a representation of combinations between other groups or columns.
 
 ## Demo
 
@@ -64,8 +64,9 @@ Every [`igx-column-group`]({environment:angularApiUrl}/classes/igxcolumngroupcom
 ### API References
 <div class="divider--half"></div>
 
-* [IgxColumnGroupComponent]({environment:angularApiUrl}/classes/igxcolumngroupcomponent.html)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
 * [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxColumnGroupComponent]({environment:angularApiUrl}/classes/igxcolumngroupcomponent.html)
 <div class="divider--half"></div>
 
 ### Additional Resources

--- a/en/components/grid_paging.md
+++ b/en/components/grid_paging.md
@@ -222,7 +222,8 @@ After all the changes above, the following result will be achieved.
 
 ### API
 * [IgxGridComponent API]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#mixin-igx-grid)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridPaginator Styles]({environment:sassApiUrl}/index.html#function-igx-grid-paginator-theme)
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/en/components/grid_selection.md
+++ b/en/components/grid_selection.md
@@ -47,7 +47,7 @@ The grid single selection can be easily setup using the grid's [`onSelection`]({
 
 #### Multiple Selection
 
-To enable multiple row selection, the [`igx-grid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) exposes the [`rowSelectable`]({environment:angularApiUrl}/classes/igxgridcomponent.html#rowselectable) property. Setting `rowSelectable` to `true` enables a select checkbox field on each row and in the grid header. The checkbox allows users to select multiple rows, with the selection persisting through scrolling, paging, and data operations such as sorting and filtering:
+To enable multiple row selection, the [`igx-grid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) exposes the [`rowSelectable`]({environment:angularApiUrl}/classes/igxgridcomponent.html#rowselectable) property. Setting [`rowSelectable`]({environment:angularApiUrl}/classes/igxgridcomponent.html#rowselectable) to `true` enables a select checkbox field on each row and in the grid header. The checkbox allows users to select multiple rows, with the selection persisting through scrolling, paging, and data operations such as sorting and filtering:
 
 ```html
     <igx-grid #grid1 [data]="remote | async" [primaryKey]="'ProductID'" [rowSelectable]="selection" (onSelection)="handleRowSelection($event)"
@@ -66,7 +66,7 @@ To enable multiple row selection, the [`igx-grid`]({environment:angularApiUrl}/c
 ### Code Snippets
 
 #### Select rows programatically
-The below code example can be used to select one or multiple rows simultaniously (via `primaryKey`):
+The below code example can be used to select one or multiple rows simultaniously (via [`primaryKey`]({environment:angularApiUrl}/classes/igxgridcomponent.html#primarykey)):
 ```html
 <!-- in component.html -->
 <igx-grid ... [primaryKey]="'ID'">
@@ -97,7 +97,7 @@ public handleRowSelectionChange(args) {
 * [IgxGridComponent API]({environment:angularApiUrl}/classes/igxgridcomponent.html)
 * [IgxGridRowComponent API]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
 * [IgxGridCellComponent API]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
-* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#mixin-igx-grid)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/en/components/grid_sorting.md
+++ b/en/components/grid_sorting.md
@@ -81,7 +81,7 @@ You can provide grid's remote sorting by subscribing to [`onDataPreLoad`]({envir
 
 ### API
 * [IgxGridComponent API]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#mixin-igx-grid)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/en/components/grid_summaries.md
+++ b/en/components/grid_summaries.md
@@ -100,7 +100,7 @@ Note: There is an option to enable or disable summaries for specific column runt
 ...
 
 ```
-If these functions do not fulfill your requirements you can provide a custom summary for the specific columns. In order to achieve this you have to override one of the base classes [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html), [`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html) or [`IgxDateSummaryOperand`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html) according to the column data type and your needs. In this way you can redefine the existing function or you can add new functions. [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) class provides the default implementation only for `count` method. [`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html) extends [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) and provides implementation for the `min`, `max`, `sum` and `average`. `IgxDateSummaryOperand` extends [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) and additionally gives you [`earliest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#earliest) and [`latest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#latest).
+If these functions do not fulfill your requirements you can provide a custom summary for the specific columns. In order to achieve this you have to override one of the base classes [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html), [`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html) or [`IgxDateSummaryOperand`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html) according to the column data type and your needs. In this way you can redefine the existing function or you can add new functions. [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) class provides the default implementation only for [`count`]({environment:angularApiUrl}/classes/igxsummaryoperand.html#count) method. [`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html) extends [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) and provides implementation for the [`min`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#min), [`max`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#max), [`sum`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#sum) and [`average`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#average). [`IgxDateSummaryOperand`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html) extends [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) and additionally gives you [`earliest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#earliest) and [`latest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#latest).
 
 ```typescript
 import { IgxSummaryResult, IgxSummaryOperand, IgxNumberSummaryOperand, IgxDateSummaryOperand } from 'igniteui-angular/grid/grid-summary';
@@ -195,7 +195,13 @@ this.http.get<any[]>('/assets/data.json')
 ### API
 
 * [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridSummaries Styles]({environment:sassApiUrl}/index.html#function-igx-grid-summary-theme)
+* [IgxSummaryOperand]({environment:angularApiUrl}/classes/igxsummaryoperand.html)
+* [IgxNumberSummaryOperand]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html)
+* [IgxDateSummaryOperand]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html)
 * [IgxColumnGroupComponent]({environment:angularApiUrl}/classes/igxcolumngroupcomponent.html)
+* [IgxColumnComponent]({environment:angularApiUrl}/classes/igxcolumncomponent.html)
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/en/components/grid_virtualization.md
+++ b/en/components/grid_virtualization.md
@@ -6,7 +6,7 @@ _keywords: Ignite UI for Angular, UI controls, Angular widgets, web widgets, UI 
 
 ### Grid Virtualization and Performance
 
-In Ignite UI for Angular, the [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) control now utilizes the [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html#igxforof) directive and virtualizes its content both vertically and horizontally.
+In Ignite UI for Angular, the [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) control now utilizes the [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html) directive and virtualizes its content both vertically and horizontally.
 
 #### Demo
 
@@ -20,7 +20,7 @@ In Ignite UI for Angular, the [`IgxGrid`]({environment:angularApiUrl}/classes/ig
 
 ### Enabling Virtualization
 
-By utilizing the [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html#igxforof) directive the Data Grid now optimizes DOM rendering and memory consumption by rendering only what is currently visible in the view port and swapping the displayed data while the user scrolls the data horizontally/vertically. [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html)'s [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) and [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) defaults to `100%` which will enable virtualization if the content displayed cannot fit inside the available space and scrollbars are required either vertically or horizontally. However, it is also possible to explicitly set the grid's [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) and/or [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) to `null` which means that the related dimension will be determined by the total size of the items inside. No scrollbar will then be shown and all items will be rendered along the respective dimension (columns if [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) is `null` and rows if [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) is `null`).
+By utilizing the [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html) directive the Data Grid now optimizes DOM rendering and memory consumption by rendering only what is currently visible in the view port and swapping the displayed data while the user scrolls the data horizontally/vertically. [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html)'s [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) and [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) defaults to `100%` which will enable virtualization if the content displayed cannot fit inside the available space and scrollbars are required either vertically or horizontally. However, it is also possible to explicitly set the grid's [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) and/or [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) to `null` which means that the related dimension will be determined by the total size of the items inside. No scrollbar will then be shown and all items will be rendered along the respective dimension (columns if [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) is `null` and rows if [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) is `null`).
 
 The size of the data chunks is determined by:
 
@@ -33,7 +33,7 @@ Explicitly setting column widths in percentages (%) will, in most cases, create 
 
 ### Remote Virtualization
 
-[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) supports the scenario in which the data chunks are requested from a remote service, exposing the behavior implemented in the [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html#igxforof) directive it uses internally.
+[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) supports the scenario in which the data chunks are requested from a remote service, exposing the behavior implemented in the [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html) directive it uses internally.
 
 ### Grid Remote Virtualization Demo
 
@@ -112,6 +112,7 @@ Without information about the sizes of the container and the items before render
 
 ### API
 * [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+*  [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 * [IgxColumnComponent]({environment:angularApiUrl}/classes/igxcolumncomponent.html)
 * [IgxForOfDirective]({environment:angularApiUrl}/classes/igxforofdirective.html)
 * [IForOfState]({environment:angularApiUrl}/interfaces/iforofstate.html)

--- a/jp/components/grid_editing.md
+++ b/jp/components/grid_editing.md
@@ -22,10 +22,10 @@ Ignite UI for Angular の Grid コンポーネントは、列のデータ型に�
 
 特定のセルで編集モードに入るには、最初に列を**編集可能**にする必要があります。データ型固有の編集テンプレートを使用する場合は、列 [`dataType`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#datatype) プロパティを指定してください。以下は各型のデフォルト テンプレートです。
 
- - `string` データ型のデフォルトのテンプレートは **igxInput** を使用します。
- - `number` データ型のデフォルト テンプレートは、**igxInput type="number"** を使用し、セルを数値に解析できない値に更新した場合は変更が破棄され、セル値は **0** に設定されます。
- - `date`データ型のデフォルトのテンプレートは  **igx-date-picker** を使用します。
- - `boolean` データ型のデフォルトのテンプレートは **igx-checkbox** を使用します。
+ - `string` データ型のデフォルトのテンプレートは [**igxInput**]({environment:angularApiUrl}/classes/igxinputdirective.html) を使用します。
+ - `number` データ型のデフォルト テンプレートは、**[igxInput]({environment:angularApiUrl}/classes/igxinputdirective.html) type="number"** を使用し、セルを数値に解析できない値に更新した場合は変更が破棄され、セル値は **0** に設定されます。
+ - `date`データ型のデフォルトのテンプレートは  [**igx-date-picker**]({environment:angularApiUrl}/classes/igxdatepickercomponent.html) を使用します。
+ - `boolean` データ型のデフォルトのテンプレートは [**igx-checkbox**]({environment:angularApiUrl}/classes/igxcheckboxcomponent.html) を使用します。
 
 以下のいずれかの方法でセルがフォーカスされている場合、編集モードに入ることができます。
  - ダブル クリック
@@ -129,8 +129,14 @@ row.delete();
 <div class="divider--half"></div>
 
 ### API
-* [`IgxGridCellComponent`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
-* [`IgxGridRowComponent`]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
+* [IgxGridCellComponent]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridRowComponent]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
+* [IgxInputDirective]({environment:angularApiUrl}/classes/igxinputdirective.html)
+* [IgxDatePickerComponent]({environment:angularApiUrl}/classes/igxdatepickercomponent.html)
+* [IgxDatePickerComponent Styles]({environment:sassApiUrl}/index.html#function-igx-date-picker-theme)
+* [IgxCheckboxComponent]({environment:angularApiUrl}/classes/igxcheckboxcomponent.html)
+* [IgxCheckboxComponent Styles]({environment:sassApiUrl}/index.html#function-igx-checkbox-theme)
 
 <div class="divider--half"></div>
 

--- a/jp/components/grid_multi_column_headers.md
+++ b/jp/components/grid_multi_column_headers.md
@@ -7,7 +7,7 @@ _language: ja
 
 ## 複数列ヘッダー
 
-`igxGrid` は、列ヘッダーの下に行を配置した行のグループ化が可能な `multi-column headers` をサポートします。各 `column group` は、その他のグループや列を組み合わせて表示できます。
+[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) は、列ヘッダーの下に行を配置した行のグループ化が可能な `multi-column headers` をサポートします。各 `column group` は、その他のグループや列を組み合わせて表示できます。
 
 ## デモ
 
@@ -65,8 +65,9 @@ _language: ja
 ### API まとめ
 <div class="divider--half"></div>
 
-* [IgxColumnGroupComponent]({environment:angularApiUrl}/classes/igxcolumngroupcomponent.html)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
 * [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxColumnGroupComponent]({environment:angularApiUrl}/classes/igxcolumngroupcomponent.html)
 
 <div class="divider--half"></div>
 

--- a/jp/components/grid_paging.md
+++ b/jp/components/grid_paging.md
@@ -224,7 +224,8 @@ public ngAfterViewInit() {
 
 ### API
 * [IgxGridComponent API]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [IgxGridComponent スタイル]({environment:sassApiUrl}/index.html#mixin-igx-grid)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridPaginator Styles]({environment:sassApiUrl}/index.html#function-igx-grid-paginator-theme)
 
 ### その他のリソース
 <div class="divider--half"></div>

--- a/jp/components/grid_selection.md
+++ b/jp/components/grid_selection.md
@@ -48,7 +48,7 @@ Ignite UI for Angular 行選択は、行内のすべての列の前に描画さ�
 
 #### 複数選択
 
-複数行選択を有効にするには、[`igx-grid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) の [`rowSelectable`]({environment:angularApiUrl}/classes/igxgridcomponent.html#rowselectable) プロパティを使用します。`rowSelectable` を `true` に設定すると、各行およびグリッド ヘッダーで選択チェックボックス フィールドが有効になります。チェックボックスを使用して複数行を選択でき、スクロール、ページング、および並べ替えとフィルターなどのデータ操作で選択が保持されます。
+複数行選択を有効にするには、[`igx-grid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) の [`rowSelectable`]({environment:angularApiUrl}/classes/igxgridcomponent.html#rowselectable) プロパティを使用します。[`rowSelectable`]({environment:angularApiUrl}/classes/igxgridcomponent.html#rowselectable) を `true` に設定すると、各行およびグリッド ヘッダーで選択チェックボックス フィールドが有効になります。チェックボックスを使用して複数行を選択でき、スクロール、ページング、および並べ替えとフィルターなどのデータ操作で選択が保持されます。
 
 ```html
     <igx-grid #grid1 [data]="remote | async" [primaryKey]="'ProductID'" [rowSelectable]="selection" (onSelection)="handleRowSelection($event)"
@@ -67,7 +67,7 @@ Ignite UI for Angular 行選択は、行内のすべての列の前に描画さ�
 
 #### コードで行を選択
 
-以下のコード例は `primaryKey` を使用して単一または複数行を選択します。
+以下のコード例は [`primaryKey`]({environment:angularApiUrl}/classes/igxgridcomponent.html#primarykey) を使用して単一または複数行を選択します。
 
 ```html
 <!-- in component.html -->
@@ -102,7 +102,7 @@ public handleRowSelectionChange(args) {
 * [IgxGridComponent API]({environment:angularApiUrl}/classes/igxgridcomponent.html)
 * [IgxGridRowComponent API]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
 * [IgxGridCellComponent API]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
-* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#mixin-igx-grid)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 
 ### 追加のリソース
 <div class="divider--half"></div>

--- a/jp/components/grid_sorting.md
+++ b/jp/components/grid_sorting.md
@@ -82,7 +82,7 @@ public ngOnInit() {
 
 ### API
 * [IgxGridComponent API]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#mixin-igx-grid)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 
 ### 追加のリソース
 <div class="divider--half"></div>

--- a/jp/components/grid_summaries.md
+++ b/jp/components/grid_summaries.md
@@ -100,7 +100,7 @@ public disableSummary() {
 
 ```
 
-この関数が要件に合わない場合、指定した列にカスタム集計を提供できます。これを実装するには、列のデータ型に基づいて [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html)、[`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html)、または [`IgxDateSummaryOperand`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html) の基本クラスをオーバーライドします。このように既存の関数を変更または新しい関数を追加できます。[`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) クラスのデフォルト集計は `count` メソッドのみです。[`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html) は [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) を拡張し、`min`、`max`、`sum`、および `average` 集計を提供します。[`IgxDateSummaryOperand`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html) は [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) を拡張し、[`earliest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#earliest) および [`latest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#latest) を提供します。
+この関数が要件に合わない場合、指定した列にカスタム集計を提供できます。これを実装するには、列のデータ型に基づいて [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html)、[`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html)、または [`IgxDateSummaryOperand`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html) の基本クラスをオーバーライドします。このように既存の関数を変更または新しい関数を追加できます。[`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) クラスのデフォルト集計は [`count`]({environment:angularApiUrl}/classes/igxsummaryoperand.html#count) メソッドのみです。[`IgxNumberSummaryOperand`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html) は [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) を拡張し、[`min`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#min)、[`max`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#max)、[`sum`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#sum)、および [`average`]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html#average) 集計を提供します。[`IgxDateSummaryOperand`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html) は [`IgxSummaryOperand`]({environment:angularApiUrl}/classes/igxsummaryoperand.html) を拡張し、[`earliest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#earliest) および [`latest`]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html#latest) を提供します。
 
 ```typescript
 import { IgxSummaryResult, IgxSummaryOperand, IgxNumberSummaryOperand, IgxDateSummaryOperand } from 'igniteui-angular/grid/grid-summary';
@@ -198,7 +198,13 @@ this.http.get<any[]>('/assets/data.json')
 ### API
 
 * [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridSummaries Styles]({environment:sassApiUrl}/index.html#function-igx-grid-summary-theme)
+* [IgxSummaryOperand]({environment:angularApiUrl}/classes/igxsummaryoperand.html)
+* [IgxNumberSummaryOperand]({environment:angularApiUrl}/classes/igxnumbersummaryoperand.html)
+* [IgxDateSummaryOperand]({environment:angularApiUrl}/classes/igxdatesummaryoperand.html)
 * [IgxColumnGroupComponent]({environment:angularApiUrl}/classes/igxcolumngroupcomponent.html)
+* [IgxColumnComponent]({environment:angularApiUrl}/classes/igxcolumncomponent.html)
 
 ### 追加のリソース
 <div class="divider--half"></div>

--- a/jp/components/grid_virtualization.md
+++ b/jp/components/grid_virtualization.md
@@ -7,7 +7,7 @@ _language: ja
 
 ### グリッドの仮想化とパフォーマンス
 
-Ignite UI for Angular [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) コントロールは [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html#igxforof) ディレクティブを使用します。コンテンツを垂直方向 (データ レコード) および水平方向 (列) に仮想化します。
+Ignite UI for Angular [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) コントロールは [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html) ディレクティブを使用します。コンテンツを垂直方向 (データ レコード) および水平方向 (列) に仮想化します。
 
 #### デモ
 
@@ -21,7 +21,7 @@ Ignite UI for Angular [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcom
 
 ### 仮想化の有効化
 
-[`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html#igxforof) ディレクティブは、ビューポートに表示されているデータのみを描画し、ユーザーがスクロール時に表示データを切り替えた際に Data Grid が DOM 描画およびメモリ使用を最適化します。[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) の [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) および [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) のデフォルト値は 100% です。コンテンツが利用可能なスペースにフィットせず、垂直方向または水平方向にスクロールバーが必要な場合に仮想化が有効になります。ただし、グリッドの [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) または [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) を明示的に `null` 値に設定できます。つまり、関連するディメンションが項目の合計サイズに基づいて決定されます。スクロールバーが表示されず、すべての項目が相対するディメンション ([`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) が `null` 値の場合は列で、[`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) が `null` 値の場合は行) に描画されます。
+[`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html) ディレクティブは、ビューポートに表示されているデータのみを描画し、ユーザーがスクロール時に表示データを切り替えた際に Data Grid が DOM 描画およびメモリ使用を最適化します。[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) の [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) および [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) のデフォルト値は 100% です。コンテンツが利用可能なスペースにフィットせず、垂直方向または水平方向にスクロールバーが必要な場合に仮想化が有効になります。ただし、グリッドの [`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) または [`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) を明示的に `null` 値に設定できます。つまり、関連するディメンションが項目の合計サイズに基づいて決定されます。スクロールバーが表示されず、すべての項目が相対するディメンション ([`width`]({environment:angularApiUrl}/classes/igxgridcomponent.html#width) が `null` 値の場合は列で、[`height`]({environment:angularApiUrl}/classes/igxgridcomponent.html#height) が `null` 値の場合は行) に描画されます。
 
 データ部分のサイズは以下によって決定されます。
 
@@ -34,7 +34,7 @@ Ignite UI for Angular [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcom
 
 ### リモート仮想化
 
-[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) は、データ部分がリモート サービスから要求されたシナリオをサポートします。このシナリオは内部に使用される [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html#igxforof) で実装される動作を公開します。
+[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) は、データ部分がリモート サービスから要求されたシナリオをサポートします。このシナリオは内部に使用される [`igxForOf`]({environment:angularApiUrl}/classes/igxforofdirective.html) で実装される動作を公開します。
 
 ### Grid リモート仮想化デモ
 
@@ -98,7 +98,7 @@ public processData() {
 ### 仮想化の制限
 
 *   行の高さの変更はサポートされません。すべての行を同じ高さに設定する必要があります。
-*   行/列の指定したディメンションが実際の描画された要素と一致する必要があります。たとえば、グリッド セルに行の高さを高くするテンプレートまたはクラスを定義した際に指定した `rowHeight` 値と一致しない場合、垂直仮想化は正しく動作しません。仮想項目数は DOM の実際要素と一致しなくなり、列およびその幅も同様になります。
+*   行/列の指定したディメンションが実際の描画された要素と一致する必要があります。たとえば、グリッド セルに行の高さを高くするテンプレートまたはクラスを定義した際に指定した [`rowHeight`]({environment:angularApiUrl}/classes/igxgridcomponent.html#rowheight) 値と一致しない場合、垂直仮想化は正しく動作しません。仮想項目数は DOM の実際要素と一致しなくなり、列およびその幅も同様になります。
 *   ブラウザーは現在 DOM 要素に高さの制限があります。そのため、行の高さの合計をブラウザーの高さの制限より大きくする必要があります。より大きくなる場合、[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html) が正しく動作しない可能性があります。たとえば、Internet Explorer 11 の高さの制限は 1,533,916 ピクセルです。つまり、高さが 50px の行の制限は 30,678 行です。
 *   グリッドにレスポンシブな幅または高さがあり、ブラウザーのウィンドウまたはその他の要素のサイズに合わせてサイズ変更する場合、スクロール位置は 0 にリセットされます。スクロールバーの位置およびサイズ変更については、今後のリリースで機能拡張が予定されています。
 *   Mac OS で 「Show scrollbars only when scrolling」システム オプションを true (デフォルト値) に設定した場合、水平スクロールバーが表示されません。これは、グリッドの行コンテナーで、overflow が hidden に設定されているためです。オプションを "Always" に設定すると、スクロールバーが表示されます。
@@ -113,6 +113,7 @@ public processData() {
 
 ### API
 * [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+*  [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 * [IgxColumnComponent]({environment:angularApiUrl}/classes/igxcolumncomponent.html)
 * [IgxForOfDirective]({environment:angularApiUrl}/classes/igxforofdirective.html)
 * [IForOfState]({environment:angularApiUrl}/interfaces/iforofstate.html)


### PR DESCRIPTION
Closes #729 

Configuring Typedoc and Sassdoc references for topics:

-   Grid Virtualization
-   Grid Editing
-   Grid Sorting
-   Grid Summaries
-   Grid Paging
-   Grid Selection
-   Grid Display Density