### PR TITLE
Added some recommended SEO improvements

### DIFF
--- a/en/components/grids_and_lists.md
+++ b/en/components/grids_and_lists.md
@@ -1,7 +1,7 @@
 ---
-title: Data Grids and Lists Components
-_description: Ignite UI for Angular provides the fastest Angular Data Grid, high-speed rendering, and Material-based components for a powerful Angular grid and features. 
-_keywords: Ignite UI for Angular, Angular, Native Angular Components Suite, Native Angular Controls, Native Angular Components, Native Angular Components Library, Angular Grid, Angular Data Grid, Angular Grid Control, Angular Grid Component
+title: Angular Data Grids and Lists Components | DataTable | Ignite UI for Angular | Infragistics
+_description: Find powerful grid features for no-lag scrolling through millions of data points. Ignite UI for Angular’s Data Grid is built for optimization and speed.
+_keywords: angular data grid,infragistics, infragistics.com
 ---
 
 <div class="feature feature--hero">

--- a/en/components/grids_and_lists.md
+++ b/en/components/grids_and_lists.md
@@ -6,8 +6,8 @@ _keywords: Ignite UI for Angular, Angular, Native Angular Components Suite, Nati
 
 <div class="feature feature--hero">
   <div class="feature__details">
-    <h2 id="the-fastest-data-angular-data-grid">The Fastest Angular Data Grid</h2>
-    <p>Ignite UI for Angular’s [Data Grid](grid.md) is built for optimization, speed, high-performance, and smooth handling of large data sets. With an updated virtualization directive and powerful grid features, your data grid is ready for no-lag scrolling through millions of data points.</p>
+    <h1 id="the-fastest-data-angular-data-grid" class="h2">The Fastest Angular Data Grid</h1>
+    <p>Ignite UI for Angular’s [Data Grid](grid.md) is built for optimization, speed, high-performance, and smooth handling of large data sets. With an updated virtualization directive and powerful grid features, your virtualized data grid is ready for no-lag scrolling through millions of data points.</p>
     <a class="cta-btn" href="https://www.infragistics.com/products/ignite-ui-angular/download">get started for free</a>
   </div>
   <div class="feature__image feature__image--right">
@@ -25,7 +25,7 @@ _keywords: Ignite UI for Angular, Angular, Native Angular Components Suite, Nati
     </div>
     <div class="feature__details">
       <h3 id="virtualization-and-performance">[Virtualization and Performance](grid_virtualization.md)</h3>
-      <p>Seamlessly scroll unlimited rows and columns in your Angular grid with the data grid’s column and row level virtualization.  Your users will experience Excel-like scrolling performance - no lag, screen flicker or visual delay – giving you the best user experience with no compromise in performance.</p>
+      <p>Seamlessly scroll unlimited rows and columns in your [Angular grid with the data grid’s](/products/ignite-ui-angular/grid) column and row level virtualization.  Your users will experience Excel-like scrolling performance - no lag, screen flicker or visual delay – giving you the best user experience with no compromise in performance.</p>
     </div>
   </div>
 

--- a/jp/components/grids_and_lists.md
+++ b/jp/components/grids_and_lists.md
@@ -8,7 +8,7 @@ _language: ja
 <div class="feature feature--hero">
   <div class="feature__details">
     <h1 id="the-fastest-data-angular-data-grid" class="h2">高速 Angular データ グリッド</h1>
-    <p>Ignite UI for Angular の [Data Grid](grid.md)   は、サイズの大きなデータセットの高速処理など高パフォーマンスに最適化されています。仮想ディレクティブとパワフルなグリッド機能により、数百のデータ ポイントを遅延なしでスクロールできます。</p>
+    <p>Ignite UI for Angular の [Data Grid](grid.md) は、大規模なデータセットの高速処理など高パフォーマンスを念頭に最適化されています。仮想ディレクティブとパワフルなグリッド機能により、仮想データグリッドでは数百のデータ ポイントを遅延なしでスクロールできます。</p>
     <a class="cta-btn" href="https://jp.infragistics.com/products/ignite-ui-angular/getting-started">無償版ダウンロード</a>
   </div>
   <div class="feature__image feature__image--right">
@@ -26,7 +26,7 @@ _language: ja
     </div>
     <div class="feature__details">
       <h3 id="virtualization-and-performance">[仮想化とパフォーマンス](grid_virtualization.md)</h3>
-      <p>Angular グリッドのデータ グリッド列やレベルの仮想化機能は、行や列を行数/列数に関係なく無制限に、そしてシームレスにスクロールできます。遅延、画面のちらつきなどのない Excel のようなスクロールをユーザーに提供できます。</p>
+      <p>[Angular グリッドのデータ グリッド](/products/ignite-ui-angular) の列やレベルの仮想化機能は、行や列を行数/列数に関係なく無制限に、そしてシームレスにスクロールできます。遅延や画面のちらつきなどのない Excel のようなスクロールをユーザーに提供できます。</p>
     </div>
   </div>
 

--- a/jp/components/grids_and_lists.md
+++ b/jp/components/grids_and_lists.md
@@ -7,7 +7,7 @@ _language: ja
 
 <div class="feature feature--hero">
   <div class="feature__details">
-    <h2 id="the-fastest-data-angular-data-grid">高速 Angular データ グリッド</h2>
+    <h1 id="the-fastest-data-angular-data-grid" class="h2">高速 Angular データ グリッド</h1>
     <p>Ignite UI for Angular の [Data Grid](grid.md)   は、サイズの大きなデータセットの高速処理など高パフォーマンスに最適化されています。仮想ディレクティブとパワフルなグリッド機能により、数百のデータ ポイントを遅延なしでスクロールできます。</p>
     <a class="cta-btn" href="https://jp.infragistics.com/products/ignite-ui-angular/getting-started">無償版ダウンロード</a>
   </div>

--- a/jp/components/grids_and_lists.md
+++ b/jp/components/grids_and_lists.md
@@ -1,7 +1,7 @@
 ﻿---
-title: Data Grids および Lists コンポーネント
-_description: Ignite UI for Angular は、高速な Angular Data Grid と描画、パワフルな Angular グリッドにマテリアル ベースのコンポーネントです。
-_keywords: Ignite UI for Angular, Angular, ネイティブ Angular コンポーネント スイート, ネイティブ Angular コントロール, ネイティブ Angular コンポーネント, ネイティブ Angular コンポーネント ライブラリ, Angular グリッド, Angular データグリッド, Angular グリッドコントロール, Angular グリッドコンポーネント
+title: Angular Data Grids と Lists コンポーネント | DataTable | Ignite UI for Angular | Infragistics
+_description: 数百のデータ ポイント可視化においてもタイムラグのないスクロールを提供できるパワフルなグリッド機能を備えています。Ignite UI for Angular の Data Grid は、最適化と高速化を実現します。
+_keywords: angular data grid,infragistics, infragistics.com
 _language: ja
 ---
 

--- a/kr/components/grids_and_lists.md
+++ b/kr/components/grids_and_lists.md
@@ -7,7 +7,7 @@ _language: kr
 
 <div class="feature feature--hero">
   <div class="feature__details">
-    <h2 id="the-fastest-data-angular-data-grid">고속 Angular 데이터 그리드</h2>
+    <h1 id="the-fastest-data-angular-data-grid" class="h2">고속 Angular 데이터 그리드</h1>
     <p>Ignite UI for Angular의 데이터 그리드는 대규모 데이터 세트의 최적화, 고속 및 고성능 처리를 위해 제작되었습니다.업데이트된 가상화 지시문 및 강력한 그리드 기능으로 수백만 개의 데이터 점을 지연 시간 없이 스크롤할 수 있습니다.</p>
     <a class="cta-btn" href="https://www.infragistics.com/products/ignite-ui-angular/download">무료로 시작하기</a>
   </div>


### PR DESCRIPTION
I had to make some minor updates for SEO purposes. EN is ready to go, but there two minor changes that need to be updated for JP and KR sites. 

@yoshimis I already applied one of the changes by switch the h2 to an h1, but we also added the word "virtualized" in the opening paragraph. The additional change of adding a link on the Virtualization and Performance description isn't applicable to JP and KR websites, so that could be skipped.

@pamelabrasil, @zdrawku and @tiliev please let me know if you have any questions regarding this. These changes can go live anytime your ready.