### PR TITLE
Exclude auto-generated topics from watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,8 +45,21 @@ gulp.task('serve', ['build'], () => {
         }
     });
 
+    const excluded = [
+        `!${DOCFX_ARTICLES}/grid/**`,
+        `!${DOCFX_ARTICLES}/treeGrid/**`,
+        `!${DOCFX_ARTICLES}/hierarchicalGrid/**`
+    ];
+
+    // All topics that are not auto-generated and are specific to the respective grid, should be here.
+    const included = [
+        `${DOCFX_ARTICLES}/grid/grid.md`,
+        `${DOCFX_ARTICLES}/treeGrid/tree_grid.md`,
+        `${DOCFX_ARTICLES}/hierarchicalGrid/hierarchical_grid.md`
+    ];
+
     gulp.watch(`${DOCFX_TEMPLATE}/**/*`, ['watch']);
-    gulp.watch([`${DOCFX_PATH}/**/*.md`, `${DOCFX_ARTICLES}/**`], ['build']);
+    gulp.watch([`${DOCFX_PATH}/**/*.md`, `${DOCFX_ARTICLES}/**`].concat(excluded).concat(included), ['build']);
 });
 
 gulp.task('styles', () => {


### PR DESCRIPTION
Closes #1008 

Issue was caused by the fact that whenever a template is saved, the watch triggers not only because of it, but also because of the topics that are generated by the template. These generated topics trigger the build task, which on the other hand triggers the **generate-grid-topics** task, which leads to flooding and error.

Currently we exclude all auto-generated topics and include manually in the **gulpfile.js** only the grid specific topics, for which the watch should be working.