### PR TITLE
Even 7.1.x and master

### DIFF
--- a/en/components/combo_templates.md
+++ b/en/components/combo_templates.md
@@ -41,23 +41,23 @@ Defining templates for item, header, footer and empty one is achieved using pred
 ```html
 <igx-combo #templateCombo [data]="lData" [valueKey]="'field'" >
 
-    <ng-template #itemTemplate let-display let-key="valueKey">
+    <ng-template igxComboItem let-display let-key="valueKey">
         <div class="item">
             <span class="state">{{ display[key] }} - </span>
             <span class="region">{{ display.region }}</span>
         </div>
     </ng-template>
 
-    <ng-template #headerTemplate>
+    <ng-template igxComboHeader>
         <div class="header-class">State - Region</div>
     </ng-template>
 
-    <ng-template #footerTemplate>
+    <ng-template igxComboFooter>
         <div class="footer-class">Infragistics 2018</div>
     </ng-template>
 
     <igx-combo>
-        <ng-template #emptyTemplate>
+        <ng-template igxComboEmpty>
             <span class="empty-class">No available states</span>
         </ng-template>
     </igx-combo>
@@ -68,11 +68,11 @@ Defining templates for item, header, footer and empty one is achieved using pred
 When defining one of the templates below, you need to reference them using the following predefined names:
 
 ### Item template
-Use reference name **`itemTemplate`**:
+Use selector `[igxComboItem]`:
 
 ```html
 <igx-combo>
-	<ng-template #itemTemplate let-display let-key="valueKey">
+	<ng-template igxComboItem let-display let-key="valueKey">
 		<div class="item">
 			<span class="state">State: {{ display[key] }}</span>
 			<span class="region">Region: {{ display.region }}</span>
@@ -82,11 +82,11 @@ Use reference name **`itemTemplate`**:
 ```
 
 ### Header template
-Use reference name **`headerTemplate`**:
+Use selector `[igxComboHeader]`:
 
 ```html
 <igx-combo>
-    <ng-template #headerTemplate>
+    <ng-template igxComboHeader>
         <div class="header-class">Custom header</div>
         <img src=""/>
     </ng-template>
@@ -94,11 +94,11 @@ Use reference name **`headerTemplate`**:
 ```
 
 ### Footer template
-Use reference name **`footerTemplate`**:
+Use selector `[igxComboFooter]`:
 
 ```html
 <igx-combo>
-    <ng-template #footerTemplate>
+    <ng-template igxComboFooter>
         <div class="footer-class">Custom footer</div>
         <img src=""/>
     </ng-template>
@@ -106,27 +106,65 @@ Use reference name **`footerTemplate`**:
 ```
 
 ### Empty template
-Use reference name **`emptyTemplate`**:
+Use selector `[igxComboEmpty]`:
 
 ```html
 <igx-combo>
-    <ng-template #emptyTemplate>
+    <ng-template igxComboEmpty>
         <span>List is empty</div>
     </ng-template>
 </igx-combo>
 ```
 
 ### Add template
-Use reference name **`addItemTemplate`**:
+Use selector `[igxComboAddItem]`:
 
 ```html
 <igx-combo>
-    <ng-template #addItemTemplate>
+    <ng-template igxComboAddItem>
         <span>Add town</span>
     </ng-template>
 </igx-combo>
 ```
+
+### Toggle Icon Template
+Use selector `[igxComboToggleIcon]`:
+
+```html
+<igx-combo>
+    <ng-template igxComboToggleIcon let-collapsed>
+        <igx-icon>{{ collapsed ? 'remove_circle' : 'remove_circle_outline'}}</igx-icon>
+    </ng-template>
+</igx-combo>
+```
+
+### Clear Icon Template
+Use selector `[igxComboClearIcon]`:
+
+```html
+<igx-combo>
+    <ng-template igxComboClearIcon>
+        <igx-icon>music_off</igx-icon>
+    </ng-template>
+</igx-combo>
+```
+
 <div class="divider--half"></div>
+
+### Templating combo input
+The above-mentioned selectors, `[igxComboClearIcon]` and `[igxComboToggleIcon]`, used with templates will change how the respective buttons appear in the combo input. 
+Passing content inside of the `igx-combo` also allows templating of the combo input similar to the way an `igx-input-group` can be templated (using `igx-prefix`, `igx-suffix` and `[igxLabel]`). The code snippet below illustrates how to add an appropriate label and `igx-prefix` to the combo input, as well as changing the `clear` button icon:
+```html
+    <igx-combo [data]="myMusic">
+        ...
+        <label igxLabel>Genres</label>
+        <igx-prefix><igx-icon>music_note</igx-icon></igx-prefix>
+        <ng-template igxComboClearIcon>
+            <igx-icon>music_off</igx-icon>
+        </ng-template>
+        ...
+    </igx-combo>
+```
 
 ## Additional Resources
 <div class="divider--half"></div>

--- a/en/components/datachart_axis_locations.md
+++ b/en/components/datachart_axis_locations.md
@@ -8,6 +8,18 @@ _keywords: Ignite UI for Angular, Angular, Native Angular Components Suite, Nati
 
  For all axes have, you can specify axis location in relationship to chart plot area. This especially important when using more than two axes in the same chart or when [Sharing Axis](datachart_axis_sharing.md) between multiple series.
 
+### Demo
+
+<div class="sample-container" style="height: 300px">
+    <iframe id="data-chart-axis-locations-iframe" src='{environment:demosBaseUrl}/charts/data-chart-axis-locations' width="100%" height="100%" seamless frameBorder="0" onload="onSampleIframeContentLoaded(this);"></iframe>
+</div>
+<div>
+    <button data-localize="stackblitz" disabled class="stackblitz-btn" data-iframe-id="data-chart-axis-locations-iframe" data-demos-base-url="{environment:demosBaseUrl}">View on StackBlitz
+    </button>
+</div>
+
+<div class="divider--half"></div>
+
 ### Code Example
 
 This code demonstrates how to create data chart with two `IgxNumericYAxisComponent` that will be placed on left/right sides and two `IgxCategoryXAxisComponent` that will be stacked on one another.

--- a/en/global.json
+++ b/en/global.json
@@ -1,7 +1,7 @@
 {
     "_navBarTitle": "Ignite UI for Angular",
     "_repoUrl": "https://github.com/IgniteUI/igniteui-docfx/tree/master/en/",
-    "_navBarTitleHref": "https://infragistics.com/products/ignite-ui-angular/",
+    "_navBarTitleHref": "https://www.infragistics.com/products/ignite-ui-angular",
     "_currentBaseUrl": "https://www.infragistics.com/products/ignite-ui-angular/angular/",
     "_hasKRLang": true,
     "_ENBaseUrl": "https://www.infragistics.com/products/ignite-ui-angular/angular/",

--- a/jp/components/combo_templates.md
+++ b/jp/components/combo_templates.md
@@ -42,23 +42,23 @@ export class AppModule {}
 ```html
 <igx-combo #templateCombo [data]="lData" [valueKey]="'field'" >
 
-    <ng-template #itemTemplate let-display let-key="valueKey">
+    <ng-template igxComboItem let-display let-key="valueKey">
         <div class="item">
             <span class="state">{{ display[key] }} - </span>
             <span class="region">{{ display.region }}</span>
         </div>
     </ng-template>
 
-    <ng-template #headerTemplate>
+    <ng-template igxComboHeader>
         <div class="header-class">State - Region</div>
     </ng-template>
 
-    <ng-template #footerTemplate>
+    <ng-template igxComboFooter>
         <div class="footer-class">Infragistics 2018</div>
     </ng-template>
 
     <igx-combo>
-        <ng-template #emptyTemplate>
+        <ng-template igxComboEmpty>
             <span class="empty-class">No available states</span>
         </ng-template>
     </igx-combo>
@@ -69,11 +69,11 @@ export class AppModule {}
 以下のいずれかのテンプレートを定義した場合、定義済みの名前を使用して参照してください。
 
 ### 項目テンプレート
-参照名 **`itemTemplate`** の使用
+セレクター `[igxComboItem]` の使用:
 
 ```html
 <igx-combo>
-	<ng-template #itemTemplate let-display let-key="valueKey">
+	<ng-template igxComboItem let-display let-key="valueKey">
 		<div class="item">
 			<span class="state">State: {{ display[key] }}</span>
 			<span class="region">Region: {{ display.region }}</span>
@@ -83,11 +83,11 @@ export class AppModule {}
 ```
 
 ### ヘッダー テンプレート
-参照名 **`headerTemplate`** を使用
+Use selector `[igxComboHeader]`:
 
 ```html
 <igx-combo>
-    <ng-template #headerTemplate>
+    <ng-template igxComboHeader>
         <div class="header-class">Custom header</div>
         <img src=""/>
     </ng-template>
@@ -95,11 +95,11 @@ export class AppModule {}
 ```
 
 ### フッター テンプレート
-参照名 **`footerTemplate`** を使用
+Use selector `[igxComboFooter]`:
 
 ```html
 <igx-combo>
-    <ng-template #footerTemplate>
+    <ng-template igxComboFooter>
         <div class="footer-class">Custom footer</div>
         <img src=""/>
     </ng-template>
@@ -107,27 +107,64 @@ export class AppModule {}
 ```
 
 ### 空のテンプレート
-参照名 **`emptyTemplate`** を使用
+Use selector `[igxComboEmpty]`:
 
 ```html
 <igx-combo>
-    <ng-template #emptyTemplate>
+    <ng-template igxComboEmpty>
         <span>List is empty</div>
     </ng-template>
 </igx-combo>
 ```
 
 ### テンプレートの追加
-参照名 **`addItemTemplate`** を使用
+セレクター `[igxComboAddItem]` の使用:
 
 ```html
 <igx-combo>
-    <ng-template #addItemTemplate>
+    <ng-template igxComboAddItem>
         <span>Add town</span>
     </ng-template>
 </igx-combo>
 ```
+
+### アイコン テンプレートの切り替え
+セレクター `[igxComboToggleIcon]` の使用:
+
+```html
+<igx-combo>
+    <ng-template igxComboToggleIcon let-collapsed>
+        <igx-icon>{{ collapsed ? 'remove_circle' : 'remove_circle_outline'}}</igx-icon>
+    </ng-template>
+</igx-combo>
+```
+
+### アイコン テンプレートのクリア
+セレクター `[igxComboClearIcon]` の使用:
+
+```html
+<igx-combo>
+    <ng-template igxComboClearIcon>
+        <igx-icon>music_off</igx-icon>
+    </ng-template>
+</igx-combo>
+```
+
 <div class="divider--half"></div>
+
+### コンボ入力のテンプレート化
+上記セレクターのテンプレートで使用される `[igxComboClearIcon]` と `[igxComboToggleIcon]` は、コンボ入力の各ボタンの表示を変更するために使用されます。`igx-combo` 内のコンテンツを渡すことにより、`igx-input-group` をテンプレート化する方法と同様のコンボ入力のテンプレート化も可能になります。 (`igx-prefix`、`igx-suffix`、`[igxLabel]`) が可能になります。以下のコード スニペットは、適切なラベルや `igx-prefix` をコンボに追加する方法、ボタン アイコンを変更する方法を示します。
+```html
+    <igx-combo [data]="myMusic">
+        ...
+        <label igxLabel>Genres</label>
+        <igx-prefix><igx-icon>music_note</igx-icon></igx-prefix>
+        <ng-template igxComboClearIcon>
+            <igx-icon>music_off</igx-icon>
+        </ng-template>
+        ...
+    </igx-combo>
+```
 
 ## その他のリソース
 <div class="divider--half"></div>

--- a/jp/global.json
+++ b/jp/global.json
@@ -1,6 +1,6 @@
 {
     "_navBarTitle": "Ignite UI for Angular",
-    "_navBarTitleHref": "https://jp.infragistics.com/products/ignite-ui-angular/",
+    "_navBarTitleHref": "https://jp.infragistics.com/products/ignite-ui-angular",
     "_repoUrl": "https://github.com/IgniteUI/igniteui-docfx/tree/master/jp/",
     "_currentBaseUrl": "https://jp.infragistics.com/products/ignite-ui-angular/angular/",
     "_hasKRLang": true,

--- a/kr/components/combo_templates.md
+++ b/kr/components/combo_templates.md
@@ -42,23 +42,23 @@ Defining templates for item, header, footer and empty one is achieved using pred
 ```html
 <igx-combo #templateCombo [data]="lData" [valueKey]="'field'" >
 
-    <ng-template #itemTemplate let-display let-key="valueKey">
+    <ng-template igxComboItem let-display let-key="valueKey">
         <div class="item">
             <span class="state">{{ display[key] }} - </span>
             <span class="region">{{ display.region }}</span>
         </div>
     </ng-template>
 
-    <ng-template #headerTemplate>
+    <ng-template igxComboHeader>
         <div class="header-class">State - Region</div>
     </ng-template>
 
-    <ng-template #footerTemplate>
+    <ng-template igxComboFooter>
         <div class="footer-class">Infragistics 2018</div>
     </ng-template>
 
     <igx-combo>
-        <ng-template #emptyTemplate>
+        <ng-template igxComboEmpty>
             <span class="empty-class">No available states</span>
         </ng-template>
     </igx-combo>
@@ -69,11 +69,11 @@ Defining templates for item, header, footer and empty one is achieved using pred
 When defining one of the templates below, you need to reference them using the following predefined names:
 
 ### Item template
-Use reference name **`itemTemplate`**:
+Use selector `[igxComboItem]`:
 
 ```html
 <igx-combo>
-	<ng-template #itemTemplate let-display let-key="valueKey">
+	<ng-template igxComboItem let-display let-key="valueKey">
 		<div class="item">
 			<span class="state">State: {{ display[key] }}</span>
 			<span class="region">Region: {{ display.region }}</span>
@@ -83,11 +83,11 @@ Use reference name **`itemTemplate`**:
 ```
 
 ### Header template
-Use reference name **`headerTemplate`**:
+Use selector `[igxComboHeader]`:
 
 ```html
 <igx-combo>
-    <ng-template #headerTemplate>
+    <ng-template igxComboHeader>
         <div class="header-class">Custom header</div>
         <img src=""/>
     </ng-template>
@@ -95,11 +95,11 @@ Use reference name **`headerTemplate`**:
 ```
 
 ### Footer template
-Use reference name **`footerTemplate`**:
+Use selector `[igxComboFooter]`:
 
 ```html
 <igx-combo>
-    <ng-template #footerTemplate>
+    <ng-template igxComboFooter>
         <div class="footer-class">Custom footer</div>
         <img src=""/>
     </ng-template>
@@ -107,27 +107,65 @@ Use reference name **`footerTemplate`**:
 ```
 
 ### Empty template
-Use reference name **`emptyTemplate`**:
+Use selector `[igxComboEmpty]`:
 
 ```html
 <igx-combo>
-    <ng-template #emptyTemplate>
+    <ng-template igxComboEmpty>
         <span>List is empty</div>
     </ng-template>
 </igx-combo>
 ```
 
 ### Add template
-Use reference name **`addItemTemplate`**:
+Use selector `[igxComboAddItem]`:
 
 ```html
 <igx-combo>
-    <ng-template #addItemTemplate>
+    <ng-template igxComboAddItem>
         <span>Add town</span>
     </ng-template>
 </igx-combo>
 ```
+
+### Toggle Icon Template
+Use selector `[igxComboToggleIcon]`:
+
+```html
+<igx-combo>
+    <ng-template igxComboToggleIcon let-collapsed>
+        <igx-icon>{{ collapsed ? 'remove_circle' : 'remove_circle_outline'}}</igx-icon>
+    </ng-template>
+</igx-combo>
+```
+
+### Clear Icon Template
+Use selector `[igxComboClearIcon]`:
+
+```html
+<igx-combo>
+    <ng-template igxComboClearIcon>
+        <igx-icon>music_off</igx-icon>
+    </ng-template>
+</igx-combo>
+```
+
 <div class="divider--half"></div>
+
+### Templating combo input
+The above-mentioned selectors, `[igxComboClearIcon]` and `[igxComboToggleIcon]`, used with templates will change how the respective buttons appear in the combo input. 
+Passing content inside of the `igx-combo` also allows templating of the combo input similar to the way an `igx-input-group` can be templated (using `igx-prefix`, `igx-suffix` and `[igxLabel]`). The code snippet below illustrates how to add an appropriate label and `igx-prefix` to the combo input, as well as changing the `clear` button icon:
+```html
+    <igx-combo [data]="myMusic">
+        ...
+        <label igxLabel>Genres</label>
+        <igx-prefix><igx-icon>music_note</igx-icon></igx-prefix>
+        <ng-template igxComboClearIcon>
+            <igx-icon>music_off</igx-icon>
+        </ng-template>
+        ...
+    </igx-combo>
+```
 
 ## Additional Resources
 <div class="divider--half"></div>

--- a/kr/global.json
+++ b/kr/global.json
@@ -1,7 +1,7 @@
 {
     "_navBarTitle": "Ignite UI for Angular",
     "_repoUrl": "https://github.com/IgniteUI/igniteui-docfx/tree/master/kr/",
-    "_navBarTitleHref": "https://kr.infragistics.com/products/ignite-ui-angular/",
+    "_navBarTitleHref": "https://kr.infragistics.com/products/ignite-ui-angular",
     "_currentBaseUrl": "https://kr.infragistics.com/products/ignite-ui-angular/angular/",
     "_hasKRLang": true,
     "_ENBaseUrl": "https://www.infragistics.com/products/ignite-ui-angular/angular/",


### PR DESCRIPTION
As we’re preparing for a release of the Ignite UI for Angular product on 28 February(see Roadmap doc) I created a 7.1.x branch in the igniteui-angular-samples repo. The master branch now uses igniteui-angular@7.2.0-beta.3 version.
For any emergency fixes to the samples that need to be deployed to production before this date, please use the 7.1.x branch. 


Related PR - https://github.com/IgniteUI/igniteui-angular-samples/pull/979
