### PR TITLE
Remove closeOnOutsideClick from samples

### DIFF
--- a/en/components/navdrawer.md
+++ b/en/components/navdrawer.md
@@ -90,7 +90,7 @@ The Navigation Drawer also integrates with [`igxNavigationService`]({environment
 Let's replace the `<main>` in **app.component.html** with the following, adding [`igxButton`](button.md) and [Icon component](icon.md) to style our toggle:
 ```html
 <main>
-  <span igxButton="icon" igxToggleAction="navigation" [closeOnOutsideClick]="false">
+  <span igxButton="icon" igxToggleAction="navigation">
     <igx-icon fontSet="material">menu</igx-icon>
   </span>
 </main>

--- a/en/components/toggle.md
+++ b/en/components/toggle.md
@@ -207,7 +207,7 @@ export class AppModule {}
 
 ```html
 <!--template.component.html-->
-<button igxToggleAction="toggleId" [closeOnOutsideClick]="true" class="toggle-button"  igxButton="raised">Toggle</button>
+<button igxToggleAction="toggleId" class="toggle-button"  igxButton="raised">Toggle</button>
 <div igxToggle id="toggleId" class="toggle-content">
     <section class="toggle-section">
     <h3>Click 


### PR DESCRIPTION
In `IgxToggle` and `IgxNavigationDrawer` samples we were used deprecated property `closeOnOutsideClick`. This property is removed now from all samples.

Closes #1063