### PR TITLE
Changing the  styling of links in the API links section

### DIFF
--- a/en/components/general/getting_started.md
+++ b/en/components/general/getting_started.md
@@ -222,15 +222,15 @@ The final result should look something like this:
 
 In this article we learned how to create our own Ignite UI for Angular application from scratch by taking advantage of the fully-automated process of Ignite UI for Angular projects creation in the Ignite UI CLI. We also learned and how to add Ignite UI for Angular to an existing application by using the Angular CLI. We designed our own page by including the [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) to it, which itself offers some awesome features, which you can take a look at by referring to the navigation menu.
 
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 
 ## Additional Resources
 <div class="divider--half"></div>
 
-* [`Ignite UI CLI`](https://github.com/IgniteUI/igniteui-cli)
-* [`Ignite UI CLI Commands`](https://github.com/IgniteUI/igniteui-cli/wiki#available-commands)
-* [`Grid overview`](../grid/grid.md)
+* [Ignite UI CLI](https://github.com/IgniteUI/igniteui-cli)
+* [Ignite UI CLI Commands](https://github.com/IgniteUI/igniteui-cli/wiki#available-commands)
+* [Grid overview](../grid/grid.md)
 
 <div class="divider--half"></div>
 Our community is active and always welcoming to new ideas.

--- a/en/components/grids_templates/batch_editing.md
+++ b/en/components/grids_templates/batch_editing.md
@@ -365,14 +365,14 @@ export class HierarchicalGridBatchEditingSampleComponent {
 ### API References
 
 @@if (igxName === 'IgxGrid') {
-* [`transactions`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#transactions)
-* [`igxTransactionService`]({environment:angularApiUrl}/classes/igxtransactionservice.html)
+* [transactions]({environment:angularApiUrl}/classes/@@igTypeDoc.html#transactions)
+* [igxTransactionService]({environment:angularApiUrl}/classes/igxtransactionservice.html)
 }
 @@if (igxName === 'IgxTreeGrid') {
-* [`HierarchicalTransactionService`]({environment:angularApiUrl}/classes/igxhierarchicaltransactionservice.html) 
-* [`rowEditable`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#roweditable)
-* [`IgxTreeGridComponent`]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [HierarchicalTransactionService]({environment:angularApiUrl}/classes/igxhierarchicaltransactionservice.html) 
+* [rowEditable]({environment:angularApiUrl}/classes/@@igTypeDoc.html#roweditable)
+* [IgxTreeGridComponent]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
 }
 @@if (igxName === 'IgxHierarchicalGrid') {
 * [igxHierarchicalTransactionServiceFactory]({environment:angularApiUrl}/index.html#igxhierarchicaltransactionservicefactory)

--- a/en/components/grids_templates/column_hiding.md
+++ b/en/components/grids_templates/column_hiding.md
@@ -449,36 +449,36 @@ In this article we learned how to use the built-in column hiding UI in the @@igC
 
 The column hiding UI has a few more APIs to explore, which are listed below.
 
-* [`IgxColumnHidingComponent`]({environment:angularApiUrl}/classes/igxcolumnhidingcomponent.html)
-* [`IgxColumnHidingComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-column-hiding-theme)
+* [IgxColumnHidingComponent]({environment:angularApiUrl}/classes/igxcolumnhidingcomponent.html)
+* [IgxColumnHidingComponent Styles]({environment:sassApiUrl}/index.html#function-igx-column-hiding-theme)
 
 Additional components and/or directives with relative APIs that were used:
 
 [`@@igxNameComponent`]({environment:angularApiUrl}/classes/@@igTypeDoc.html) properties:
-* [`columnHiding`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#columnhiding)
-* [`columnHidingTitle`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#columnhidingtitle)
-* [`hiddenColumnsCount`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#hiddencolumnscount)
-* [`hiddenColumnsText`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#hiddencolumnstext)
+* [columnHiding]({environment:angularApiUrl}/classes/@@igTypeDoc.html#columnhiding)
+* [columnHidingTitle]({environment:angularApiUrl}/classes/@@igTypeDoc.html#columnhidingtitle)
+* [hiddenColumnsCount]({environment:angularApiUrl}/classes/@@igTypeDoc.html#hiddencolumnscount)
+* [hiddenColumnsText]({environment:angularApiUrl}/classes/@@igTypeDoc.html#hiddencolumnstext)
 
 [`IgxColumnComponent`]({environment:angularApiUrl}/classes/igxcolumncomponent.html) properties:
-* [`disableHiding`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#disablehiding)
+* [disableHiding]({environment:angularApiUrl}/classes/igxcolumncomponent.html#disablehiding)
 
 [`IgxGridToolbarComponent`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html) properties:
-* [`columnHidingUI`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingui)
-* [`columnHidingDropdown`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingdropdown)
+* [columnHidingUI]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingui)
+* [columnHidingDropdown]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingdropdown)
 
 [`IgxGridToolbarComponent`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html) methods:
-* [`toggleColumnHidingUI`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#togglecolumnhidingui)
+* [toggleColumnHidingUI]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#togglecolumnhidingui)
 
 [`@@igxNameComponent`]({environment:angularApiUrl}/classes/@@igTypeDoc.html) events:
-* [`onColumnVisibilityChanged`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#oncolumnvisibilitychanged)
+* [onColumnVisibilityChanged]({environment:angularApiUrl}/classes/@@igTypeDoc.html#oncolumnvisibilitychanged)
 
-[`IgxRadioComponent`]({environment:angularApiUrl}/classes/igxradiocomponent.html)
+[IgxRadioComponent]({environment:angularApiUrl}/classes/igxradiocomponent.html)
 
 Styles:
 
-* [`@@igxNameComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
-* [`IgxRadioComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-radio-theme)
+* [@@igxNameComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxRadioComponent Styles]({environment:sassApiUrl}/index.html#function-igx-radio-theme)
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/en/components/grids_templates/export_excel.md
+++ b/en/components/grids_templates/export_excel.md
@@ -129,8 +129,8 @@ When you are exporting data from the @@igComponent component, the export process
 
 The Excel Exporter service has a few more APIs to explore, which are listed below.
 
-* [`IgxExcelExporterService API`]({environment:angularApiUrl}/classes/igxexcelexporterservice.html)
-* [`IgxExcelExporterOptions API`]({environment:angularApiUrl}/classes/igxexcelexporteroptions.html)
+* [IgxExcelExporterService API]({environment:angularApiUrl}/classes/igxexcelexporterservice.html)
+* [IgxExcelExporterOptions API]({environment:angularApiUrl}/classes/igxexcelexporteroptions.html)
 
 Additional components that were used:
 

--- a/en/components/grids_templates/search.md
+++ b/en/components/grids_templates/search.md
@@ -377,7 +377,7 @@ Additional components and/or directives with relative APIs that were used:
 
 Styles:
 
-* [@@igxNameComponentStyles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [@@igxNameComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 * [IgxInputGroupComponent Styles]({environment:sassApiUrl}/index.html#function-igx-input-group-theme)
 * [IgxIconComponent Styles]({environment:sassApiUrl}/index.html#function-igx-icon-theme)
 * [IgxRippleDirective Styles]({environment:sassApiUrl}/index.html#function-igx-ripple-theme)

--- a/en/components/grids_templates/search.md
+++ b/en/components/grids_templates/search.md
@@ -353,36 +353,36 @@ On the right in our input group, let's create three separate containers with the
 In this article we implemented our own search bar for the @@igComponent with some additional functionality when it comes to navigating between the search results. We also used some additional Ignite UI for Angular components like icons, chips and inputs. The search API is listed below.
 
 [`@@igxNameComponent`]({environment:angularApiUrl}/classes/@@igTypeDoc.html) methods:
--   [`findNext`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findnext)
--   [`findPrev`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findprev)
--   [`clearSearch`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#clearsearch)
--   [`refreshSearch`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#refreshsearch)
+-   [findNext]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findnext)
+-   [findPrev]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findprev)
+-   [clearSearch]({environment:angularApiUrl}/classes/@@igTypeDoc.html#clearsearch)
+-   [refreshSearch]({environment:angularApiUrl}/classes/@@igTypeDoc.html#refreshsearch)
 
 [`IgxGridCellComponent`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html) methods:
--   [`highlightText`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#highlighttext)
--   [`clearHighlight`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#clearhighlight)
+-   [highlightText]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#highlighttext)
+-   [clearHighlight]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#clearhighlight)
 
 [`IgxColumnComponent`]({environment:angularApiUrl}/classes/igxcolumncomponent.html) properties:
--   [`searchable`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#searchable)
+-   [searchable]({environment:angularApiUrl}/classes/igxcolumncomponent.html#searchable)
 
-[`ISearchInfo`]({environment:angularApiUrl}/interfaces/isearchinfo.html)
+[ISearchInfo]({environment:angularApiUrl}/interfaces/isearchinfo.html)
 
 Additional components and/or directives with relative APIs that were used:
 
-* [`IgxInputGroupComponent`]({environment:angularApiUrl}/classes/igxinputgroupcomponent.html)
-* [`IgxIconComponent`]({environment:angularApiUrl}/classes/igxiconcomponent.html)
-* [`IgxRippleDirective`]({environment:angularApiUrl}/classes/igxrippledirective.html)
-* [`IgxButtonDirective`]({environment:angularApiUrl}/classes/igxbuttondirective.html)
-* [`IgxChipComponent`]({environment:angularApiUrl}/classes/igxchipcomponent.html)
+* [IgxInputGroupComponent]({environment:angularApiUrl}/classes/igxinputgroupcomponent.html)
+* [IgxIconComponent]({environment:angularApiUrl}/classes/igxiconcomponent.html)
+* [IgxRippleDirective]({environment:angularApiUrl}/classes/igxrippledirective.html)
+* [IgxButtonDirective]({environment:angularApiUrl}/classes/igxbuttondirective.html)
+* [IgxChipComponent]({environment:angularApiUrl}/classes/igxchipcomponent.html)
 
 Styles:
 
-* [`@@igxNameComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
-* [`IgxInputGroupComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-input-group-theme)
-* [`IgxIconComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-icon-theme)
-* [`IgxRippleDirective Styles`]({environment:sassApiUrl}/index.html#function-igx-ripple-theme)
-* [`IgxButtonDirective Styles`]({environment:sassApiUrl}/index.html#function-igx-button-theme)
-* [`IgxChipComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-chip-theme)
+* [@@igxNameComponentStyles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxInputGroupComponent Styles]({environment:sassApiUrl}/index.html#function-igx-input-group-theme)
+* [IgxIconComponent Styles]({environment:sassApiUrl}/index.html#function-igx-icon-theme)
+* [IgxRippleDirective Styles]({environment:sassApiUrl}/index.html#function-igx-ripple-theme)
+* [IgxButtonDirective Styles]({environment:sassApiUrl}/index.html#function-igx-button-theme)
+* [IgxChipComponent Styles]({environment:sassApiUrl}/index.html#function-igx-chip-theme)
 
 ### Additional Resources
 <div class="divider--half"></div>

--- a/en/components/treegrid/tree_grid.md
+++ b/en/components/treegrid/tree_grid.md
@@ -250,14 +250,14 @@ The indentation of the **tree cells** persists across other tree grid features l
 
 <div class="divider--half"></div>
 
-* [`IgxTreeGridComponent`]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
-* [`IgxTreeGridCellComponent`]({environment:angularApiUrl}/classes/igxtreegridcellcomponent.html)
-* [`IgxTreeGridRowComponent`]({environment:angularApiUrl}/classes/igxtreegridrowcomponent.html)
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/#function-igx-grid-theme)
-* [`IgxGridCellComponent`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
-* [`IgxGridRowComponent`]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
-* [`IgxBaseTransactionService`]({environment:angularApiUrl}/classes/igxbasetransactionservice.html)
+* [IgxTreeGridComponent]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
+* [IgxTreeGridCellComponent]({environment:angularApiUrl}/classes/igxtreegridcellcomponent.html)
+* [IgxTreeGridRowComponent]({environment:angularApiUrl}/classes/igxtreegridrowcomponent.html)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/#function-igx-grid-theme)
+* [IgxGridCellComponent]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
+* [IgxGridRowComponent]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
+* [IgxBaseTransactionService]({environment:angularApiUrl}/classes/igxbasetransactionservice.html)
 
 
 ## Additional Resources

--- a/jp/components/general/getting_started.md
+++ b/jp/components/general/getting_started.md
@@ -222,14 +222,14 @@ ng serve
 
 このトピックでは、Ignite UI CLI. で Ignite UI for Angular プロジェクトを作成するプロセスを使用して Ignite UI for Angular アプリケーションを作成する方法について説明しました。また Ignite UI for Angular を Angular CLI を使用して既存のアプリケーションに追加する方法についてもふれました。[`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) を含むことにより、カスタムなページをデザインしてナビゲーション メニューを参照して表示できる機能が提供されます。
 
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [`IgxGridComponent スタイル`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent スタイル]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 
 ## その他のリソース
 <div class="divider--half"></div>
 
-* [`Ignite UI CLI`](https://github.com/IgniteUI/igniteui-cli)
-* [`Ignite UI CLI コマンド`](https://github.com/IgniteUI/igniteui-cli/wiki#available-commands)
+* [Ignite UI CLI](https://github.com/IgniteUI/igniteui-cli)
+* [Ignite UI CLI コマンド](https://github.com/IgniteUI/igniteui-cli/wiki#available-commands)
 * [Grid の概要](../grid/grid.md)
 
 <div class="divider--half"></div>

--- a/jp/components/grids_templates/batch_editing.md
+++ b/jp/components/grids_templates/batch_editing.md
@@ -365,14 +365,14 @@ export class HierarchicalGridBatchEditingSampleComponent {
 ### API リファレンス
 
 @@if (igxName === 'IgxGrid') {
-* [`transactions`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#transactions)
-* [`igxTransactionService`]({environment:angularApiUrl}/classes/igxtransactionservice.html)
+* [transactions]({environment:angularApiUrl}/classes/@@igTypeDoc.html#transactions)
+* [igxTransactionService]({environment:angularApiUrl}/classes/igxtransactionservice.html)
 }
 @@if (igxName === 'IgxTreeGrid') {
-* [`HierarchicalTransactionService`]({environment:angularApiUrl}/classes/igxhierarchicaltransactionservice.html) 
-* [`rowEditable`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#roweditable)
-* [`IgxTreeGridComponent`]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [HierarchicalTransactionService]({environment:angularApiUrl}/classes/igxhierarchicaltransactionservice.html) 
+* [rowEditable]({environment:angularApiUrl}/classes/@@igTypeDoc.html#roweditable)
+* [IgxTreeGridComponent]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
 }
 @@if (igxName === 'IgxHierarchicalGrid') {
 [igxHierarchicalTransactionServiceFactory]({environment:angularApiUrl}/index.html#igxhierarchicaltransactionservicefactory)

--- a/jp/components/grids_templates/column_hiding.md
+++ b/jp/components/grids_templates/column_hiding.md
@@ -258,36 +258,36 @@ export class AppModule {}
 このトピックでは、グリッドのツールバーの定義済みの列非表示 UI の使用方法や別のコンポーネントとして定義する方法について説明しました。また、その他の列順序から選択する機能を提供する UI を実装し、カスタム タイトルおよびフィルター プロンプト テキストを設定、[**IgxRadio**](../radio_button.md) ボタンのその他の Ignite UI for Angular コンポーネントも使用しました。
 以下は、列非表示 UI のその他の API です。
 
-* [`IgxColumnHidingComponent`]({environment:angularApiUrl}/classes/igxcolumnhidingcomponent.html)
-* [`IgxColumnHidingComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-column-hiding-theme)
+* [IgxColumnHidingComponent]({environment:angularApiUrl}/classes/igxcolumnhidingcomponent.html)
+* [IgxColumnHidingComponent Styles]({environment:sassApiUrl}/index.html#function-igx-column-hiding-theme)
 
 その他のコンポーネントおよびディレクティブ (またはそのいずれか) で使用した API:
 
 [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) プロパティ:
-* [`columnHiding`]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhiding)
-* [`columnHidingTitle`]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhidingtitle)
-* [`hiddenColumnsCount`]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnscount)
-* [`hiddenColumnsText`]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnstext)
+* [columnHiding]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhiding)
+* [columnHidingTitle]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhidingtitle)
+* [hiddenColumnsCount]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnscount)
+* [hiddenColumnsText]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnstext)
 
 [`IgxColumnComponent`]({environment:angularApiUrl}/classes/igxcolumncomponent.html) プロパティ:
-* [`disableHiding`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#disablehiding)
+* [disableHiding]({environment:angularApiUrl}/classes/igxcolumncomponent.html#disablehiding)
 
 [`IgxGridToolbarComponent`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html) プロパティ:
-* [`columnHidingUI`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingui)
-* [`columnHidingDropdown`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingdropdown)
+* [columnHidingUI]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingui)
+* [columnHidingDropdown]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingdropdown)
 
 [`IgxGridToolbarComponent`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html) メソッド:
-* [`toggleColumnHidingUI`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#togglecolumnhidingui)
+* [toggleColumnHidingUI]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#togglecolumnhidingui)
 
 [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) イベント:
-* [`onColumnVisibilityChanged`]({environment:angularApiUrl}/classes/igxgridcomponent.html#oncolumnvisibilitychanged)
+* [onColumnVisibilityChanged]({environment:angularApiUrl}/classes/igxgridcomponent.html#oncolumnvisibilitychanged)
 
-[`IgxRadioComponent`]({environment:angularApiUrl}/classes/igxradiocomponent.html)
+[IgxRadioComponent]({environment:angularApiUrl}/classes/igxradiocomponent.html)
 
 スタイル:
 
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
-* [`IgxRadioComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-radio-theme)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxRadioComponent Styles]({environment:sassApiUrl}/index.html#function-igx-radio-theme)
 
 ### その他のリソース
 <div class="divider--half"></div>

--- a/jp/components/grids_templates/export_excel.md
+++ b/jp/components/grids_templates/export_excel.md
@@ -132,8 +132,8 @@ this.excelExportService.export(this.@@igObjectRef, new IgxExcelExporterOptions("
 
 以下は、その他の Excel Exporter サービスの API です。
 
-* [`IgxExcelExporterService API`]({environment:angularApiUrl}/classes/igxexcelexporterservice.html)
-* [`IgxExcelExporterOptions API`]({environment:angularApiUrl}/classes/igxexcelexporteroptions.html)
+* [IgxExcelExporterService API]({environment:angularApiUrl}/classes/igxexcelexporterservice.html)
+* [IgxExcelExporterOptions API]({environment:angularApiUrl}/classes/igxexcelexporteroptions.html)
 
 使用したその他のコンポーネント:
 

--- a/jp/components/grids_templates/search.md
+++ b/jp/components/grids_templates/search.md
@@ -353,36 +353,36 @@ public clearSearch() {
 このトピックでは、@@igComponent にカスタム検索バーを実装し、更に検索結果を移動する際の機能を追加しました。アイコン、チップ、入力などその他の Ignite UI for Angular コンポーネントも使用しています。以下は検索 API です。
 
 [`@@igxNameComponent`]({environment:angularApiUrl}/classes/@@igTypeDoc.html) メソッド:
--   [`findNext`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findnext)
--   [`findPrev`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findprev)
--   [`clearSearch`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#clearsearch)
--   [`refreshSearch`]({environment:angularApiUrl}/classes/@@igTypeDoc.html#refreshsearch)
+-   [findNext]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findnext)
+-   [findPrev]({environment:angularApiUrl}/classes/@@igTypeDoc.html#findprev)
+-   [clearSearch]({environment:angularApiUrl}/classes/@@igTypeDoc.html#clearsearch)
+-   [refreshSearch]({environment:angularApiUrl}/classes/@@igTypeDoc.html#refreshsearch)
 
 [`IgxGridCellComponent`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html) メソッド:
--   [`highlightText`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#highlighttext)
--   [`clearHighlight`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#clearhighlight)
+-   [highlightText]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#highlighttext)
+-   [clearHighlight]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#clearhighlight)
 
 [`IgxColumnComponent`]({environment:angularApiUrl}/classes/igxcolumncomponent.html) プロパティ:
--   [`searchable`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#searchable)
+-   [searchable]({environment:angularApiUrl}/classes/igxcolumncomponent.html#searchable)
 
-[`ISearchInfo`]({environment:angularApiUrl}/interfaces/isearchinfo.html)
+[ISearchInfo]({environment:angularApiUrl}/interfaces/isearchinfo.html)
 
 その他のコンポーネントおよびディレクティブ (またはそのいずれか) で使用した API:
 
-* [`IgxInputGroupComponent`]({environment:angularApiUrl}/classes/igxinputgroupcomponent.html)
-* [`IgxIconComponent`]({environment:angularApiUrl}/classes/igxiconcomponent.html)
-* [`IgxRippleDirective`]({environment:angularApiUrl}/classes/igxrippledirective.html)
-* [`IgxButtonDirective`]({environment:angularApiUrl}/classes/igxbuttondirective.html)
-* [`IgxChipComponent`]({environment:angularApiUrl}/classes/igxchipcomponent.html)
+* [IgxInputGroupComponent]({environment:angularApiUrl}/classes/igxinputgroupcomponent.html)
+* [IgxIconComponent]({environment:angularApiUrl}/classes/igxiconcomponent.html)
+* [IgxRippleDirective]({environment:angularApiUrl}/classes/igxrippledirective.html)
+* [IgxButtonDirective]({environment:angularApiUrl}/classes/igxbuttondirective.html)
+* [IgxChipComponent]({environment:angularApiUrl}/classes/igxchipcomponent.html)
 
 スタイル:
 
-* [`@@igxNameComponent スタイル`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
-* [`IgxInputGroupComponent スタイル`]({environment:sassApiUrl}/index.html#function-igx-input-group-theme)
-* [`IgxIconComponent スタイル`]({environment:sassApiUrl}/index.html#function-igx-icon-theme)
-* [`IgxRippleDirective スタイル`]({environment:sassApiUrl}/index.html#function-igx-ripple-theme)
-* [`IgxButtonDirective スタイル`]({environment:sassApiUrl}/index.html#function-igx-button-theme)
-* [`IgxChipComponent スタイル`]({environment:sassApiUrl}/index.html#function-igx-chip-theme)
+* [@@igxNameComponent スタイル]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxInputGroupComponent スタイル]({environment:sassApiUrl}/index.html#function-igx-input-group-theme)
+* [IgxIconComponent スタイル]({environment:sassApiUrl}/index.html#function-igx-icon-theme)
+* [IgxRippleDirective スタイル]({environment:sassApiUrl}/index.html#function-igx-ripple-theme)
+* [IgxButtonDirective スタイル]({environment:sassApiUrl}/index.html#function-igx-button-theme)
+* [IgxChipComponent スタイル]({environment:sassApiUrl}/index.html#function-igx-chip-theme)
 
 ### その他のリソース
 <div class="divider--half"></div>

--- a/jp/components/treegrid/tree_grid.md
+++ b/jp/components/treegrid/tree_grid.md
@@ -250,14 +250,14 @@ export class MyComponent implements OnInit {
 
 <div class="divider--half"></div>
 
-* [`IgxTreeGridComponent`]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
-* [`IgxTreeGridCellComponent`]({environment:angularApiUrl}/classes/igxtreegridcellcomponent.html)
-* [`IgxTreeGridRowComponent`]({environment:angularApiUrl}/classes/igxtreegridrowcomponent.html)
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/#function-igx-grid-theme)
-* [`IgxGridCellComponent`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
-* [`IgxGridRowComponent`]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
-* [`IgxBaseTransactionService`]({environment:angularApiUrl}/classes/igxbasetransactionservice.html)
+* [IgxTreeGridComponent]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
+* [IgxTreeGridCellComponent]({environment:angularApiUrl}/classes/igxtreegridcellcomponent.html)
+* [IgxTreeGridRowComponent]({environment:angularApiUrl}/classes/igxtreegridrowcomponent.html)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/#function-igx-grid-theme)
+* [IgxGridCellComponent]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
+* [IgxGridRowComponent]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
+* [IgxBaseTransactionService]({environment:angularApiUrl}/classes/igxbasetransactionservice.html)
 
 
 ## その他のリソース

--- a/kr/components/general/getting_started.md
+++ b/kr/components/general/getting_started.md
@@ -222,15 +222,15 @@ The final result should look something like this:
 
 In this article we learned how to create our own Ignite UI for Angular application from scratch by taking advantage of the fully-automated process of Ignite UI for Angular projects creation in the Ignite UI CLI. We also learned and how to add Ignite UI for Angular to an existing application by using the Angular CLI. We designed our own page by including the [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) to it, which itself offers some awesome features, which you can take a look at by referring to the navigation menu.
 
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
 
 ## Additional Resources
 <div class="divider--half"></div>
 
-* [`Ignite UI CLI`](https://github.com/IgniteUI/igniteui-cli)
-* [`Ignite UI CLI Commands`](https://github.com/IgniteUI/igniteui-cli/wiki#available-commands)
-* [`Grid overview`](../grid/grid.md)
+* [Ignite UI CLI](https://github.com/IgniteUI/igniteui-cli)
+* [Ignite UI CLI Commands](https://github.com/IgniteUI/igniteui-cli/wiki#available-commands)
+* [Grid overview](../grid/grid.md)
 
 <div class="divider--half"></div>
 Our community is active and always welcoming to new ideas.

--- a/kr/components/grids_templates/batch_editing.md
+++ b/kr/components/grids_templates/batch_editing.md
@@ -120,9 +120,8 @@ export class GridBatchEditingSampleComponent {
 
 ## API
 
-* [`transactions`]({environment:angularApiUrl}/classes/igxgridcomponent.html#transactions)
-
-* [`igxTransactionService`]({environment:angularApiUrl}/classes/igxtransactionservice.html)
+* [transactions]({environment:angularApiUrl}/classes/igxgridcomponent.html#transactions)
+* [igxTransactionService]({environment:angularApiUrl}/classes/igxtransactionservice.html)
 
 
 ### 추가 리소스

--- a/kr/components/grids_templates/column_hiding.md
+++ b/kr/components/grids_templates/column_hiding.md
@@ -260,36 +260,36 @@ export class AppModule {}
 이 조항에서는 그리드 툴바에 내장된 열 숨기기 UI를 사용하는 방법과 별도의 컴포넌트로 정의하는 방법을 설명했습니다. 사용자가 다른 열 순서 중에서 선택할 수 있는 기능을 제공하는 UI를 장착하여 사용자 제목 및 필터 프롬프트 텍스트를 설정했습니다. 또한, Ignite UI for Angular 컴포넌트 [**IgxRadio**](../radio_button.md) 버튼을 추가로 사용했습니다.
 열 숨기기 UI에는 아래에 나열된 몇 가지 API가 추가로 포함되어 있습니다.
 
-* [`IgxColumnHidingComponent`]({environment:angularApiUrl}/classes/igxcolumnhidingcomponent.html)
-* [`IgxColumnHidingComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-column-hiding-theme)
+* [IgxColumnHidingComponent]({environment:angularApiUrl}/classes/igxcolumnhidingcomponent.html)
+* [IgxColumnHidingComponent Styles]({environment:sassApiUrl}/index.html#function-igx-column-hiding-theme)
 
 사용된 상대 API가 있는 추가 컴포넌트 및/또는 지시문:
 
 [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) properties:
-* [`columnHiding`]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhiding)
-* [`columnHidingTitle`]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhidingtitle)
-* [`hiddenColumnsCount`]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnscount)
-* [`hiddenColumnsText`]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnstext)
+* [columnHiding]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhiding)
+* [columnHidingTitle]({environment:angularApiUrl}/classes/igxgridcomponent.html#columnhidingtitle)
+* [hiddenColumnsCount]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnscount)
+* [hiddenColumnsText]({environment:angularApiUrl}/classes/igxgridcomponent.html#hiddencolumnstext)
 
 [`IgxColumnComponent`]({environment:angularApiUrl}/classes/igxcolumncomponent.html) properties:
-* [`disableHiding`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#disablehiding)
+* [disableHiding]({environment:angularApiUrl}/classes/igxcolumncomponent.html#disablehiding)
 
 [`IgxGridToolbarComponent`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html) properties:
-* [`columnHidingUI`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingui)
-* [`columnHidingDropdown`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingdropdown)
+* [columnHidingUI]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingui)
+* [columnHidingDropdown]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#columnhidingdropdown)
 
 [`IgxGridToolbarComponent`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html) methods:
-* [`toggleColumnHidingUI`]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#togglecolumnhidingui)
+* [toggleColumnHidingUI]({environment:angularApiUrl}/classes/igxgridtoolbarcomponent.html#togglecolumnhidingui)
 
 [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) events:
-* [`onColumnVisibilityChanged`]({environment:angularApiUrl}/classes/igxgridcomponent.html#oncolumnvisibilitychanged)
+* [onColumnVisibilityChanged]({environment:angularApiUrl}/classes/igxgridcomponent.html#oncolumnvisibilitychanged)
 
-[`IgxRadioComponent`]({environment:angularApiUrl}/classes/igxradiocomponent.html)
+[IgxRadioComponent]({environment:angularApiUrl}/classes/igxradiocomponent.html)
 
 스타일:
 
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
-* [`IgxRadioComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-radio-theme)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxRadioComponent Styles]({environment:sassApiUrl}/index.html#function-igx-radio-theme)
 
 ### 추가 리소스
 <div class="divider--half"></div>

--- a/kr/components/grids_templates/export_excel.md
+++ b/kr/components/grids_templates/export_excel.md
@@ -113,8 +113,8 @@ When you are exporting data from the @@igComponent component, the export process
 
 The Excel Exporter service has a few more APIs to explore, which are listed below.
 
-* [`IgxExcelExporterService API`]({environment:angularApiUrl}/classes/igxexcelexporterservice.html)
-* [`IgxExcelExporterOptions API`]({environment:angularApiUrl}/classes/igxexcelexporteroptions.html)
+* [IgxExcelExporterService API]({environment:angularApiUrl}/classes/igxexcelexporterservice.html)
+* [IgxExcelExporterOptions API]({environment:angularApiUrl}/classes/igxexcelexporteroptions.html)
 
 Additional components that were used:
 

--- a/kr/components/grids_templates/search.md
+++ b/kr/components/grids_templates/search.md
@@ -302,36 +302,36 @@ public clearSearch() {
 검색 결과의 탐색은 그리드에 사용자 검색 줄 기능을 추가하여 구현했습니다. 또한 아이콘, 칩, 입력 등의 Ignite UI for Angular 컴포넌트를 추가로 사용했습니다. 검색 API는 다음과 같습니다.
 
 [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html) methods:
--   [`findNext`]({environment:angularApiUrl}/classes/igxgridcomponent.html#findnext)
--   [`findPrev`]({environment:angularApiUrl}/classes/igxgridcomponent.html#findprev)
--   [`clearSearch`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clearsearch)
--   [`refreshSearch`]({environment:angularApiUrl}/classes/igxgridcomponent.html#refreshsearch)
+-   [findNext]({environment:angularApiUrl}/classes/igxgridcomponent.html#findnext)
+-   [findPrev]({environment:angularApiUrl}/classes/igxgridcomponent.html#findprev)
+-   [clearSearch]({environment:angularApiUrl}/classes/igxgridcomponent.html#clearsearch)
+-   [refreshSearch]({environment:angularApiUrl}/classes/igxgridcomponent.html#refreshsearch)
 
 [`IgxGridCellComponent`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html) methods:
--   [`highlightText`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#highlighttext)
--   [`clearHighlight`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#clearhighlight)
+-   [highlightText]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#highlighttext)
+-   [clearHighlight]({environment:angularApiUrl}/classes/igxgridcellcomponent.html#clearhighlight)
 
 [`IgxColumnComponent`]({environment:angularApiUrl}/classes/igxcolumncomponent.html) properties:
--   [`searchable`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#searchable)
+-   [searchable]({environment:angularApiUrl}/classes/igxcolumncomponent.html#searchable)
 
-[`ISearchInfo`]({environment:angularApiUrl}/interfaces/isearchinfo.html)
+[ISearchInfo]({environment:angularApiUrl}/interfaces/isearchinfo.html)
 
 사용된 상대 API가 있는 추가 컴포넌트 및/또는 지시문:
 
-* [`IgxInputGroupComponent`]({environment:angularApiUrl}/classes/igxinputgroupcomponent.html)
-* [`IgxIconComponent`]({environment:angularApiUrl}/classes/igxiconcomponent.html)
-* [`IgxRippleDirective`]({environment:angularApiUrl}/classes/igxrippledirective.html)
-* [`IgxButtonDirective`]({environment:angularApiUrl}/classes/igxbuttondirective.html)
-* [`IgxChipComponent`]({environment:angularApiUrl}/classes/igxchipcomponent.html)
+* [IgxInputGroupComponent]({environment:angularApiUrl}/classes/igxinputgroupcomponent.html)
+* [IgxIconComponent]({environment:angularApiUrl}/classes/igxiconcomponent.html)
+* [IgxRippleDirective]({environment:angularApiUrl}/classes/igxrippledirective.html)
+* [IgxButtonDirective]({environment:angularApiUrl}/classes/igxbuttondirective.html)
+* [IgxChipComponent]({environment:angularApiUrl}/classes/igxchipcomponent.html)
 
 스타일:
 
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
-* [`IgxInputGroupComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-input-group-theme)
-* [`IgxIconComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-icon-theme)
-* [`IgxRippleDirective Styles`]({environment:sassApiUrl}/index.html#function-igx-ripple-theme)
-* [`IgxButtonDirective Styles`]({environment:sassApiUrl}/index.html#function-igx-button-theme)
-* [`IgxChipComponent Styles`]({environment:sassApiUrl}/index.html#function-igx-chip-theme)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/index.html#function-igx-grid-theme)
+* [IgxInputGroupComponent Styles]({environment:sassApiUrl}/index.html#function-igx-input-group-theme)
+* [IgxIconComponent Styles]({environment:sassApiUrl}/index.html#function-igx-icon-theme)
+* [IgxRippleDirective Styles]({environment:sassApiUrl}/index.html#function-igx-ripple-theme)
+* [IgxButtonDirective Styles]({environment:sassApiUrl}/index.html#function-igx-button-theme)
+* [IgxChipComponent Styles]({environment:sassApiUrl}/index.html#function-igx-chip-theme)
 
 ### 추가 리소스
 <div class="divider--half"></div>

--- a/kr/components/treegrid/tree_grid.md
+++ b/kr/components/treegrid/tree_grid.md
@@ -325,14 +325,14 @@ The indentation of the **tree cells** persists across other tree grid features l
 
 <div class="divider--half"></div>
 
-* [`IgxTreeGridComponent`]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
-* [`IgxTreeGridCellComponent`]({environment:angularApiUrl}/classes/igxtreegridcellcomponent.html)
-* [`IgxTreeGridRowComponent`]({environment:angularApiUrl}/classes/igxtreegridrowcomponent.html)
-* [`IgxGridComponent`]({environment:angularApiUrl}/classes/igxgridcomponent.html)
-* [`IgxGridComponent Styles`]({environment:sassApiUrl}/#function-igx-grid-theme)
-* [`IgxGridCellComponent`]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
-* [`IgxGridRowComponent`]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
-* [`IgxBaseTransactionService`]({environment:angularApiUrl}/classes/igxbasetransactionservice.html)
+* [IgxTreeGridComponent]({environment:angularApiUrl}/classes/igxtreegridcomponent.html)
+* [IgxTreeGridCellComponent]({environment:angularApiUrl}/classes/igxtreegridcellcomponent.html)
+* [IgxTreeGridRowComponent]({environment:angularApiUrl}/classes/igxtreegridrowcomponent.html)
+* [IgxGridComponent]({environment:angularApiUrl}/classes/igxgridcomponent.html)
+* [IgxGridComponent Styles]({environment:sassApiUrl}/#function-igx-grid-theme)
+* [IgxGridCellComponent]({environment:angularApiUrl}/classes/igxgridcellcomponent.html)
+* [IgxGridRowComponent]({environment:angularApiUrl}/classes/igxgridrowcomponent.html)
+* [IgxBaseTransactionService]({environment:angularApiUrl}/classes/igxbasetransactionservice.html)
 
 
 ### Additional Resources


### PR DESCRIPTION
Some API links were decorated with ``, but in most of the topics we don't use it for API links in the "API References" section