### PR TITLE
docs(*): update mention of other components in combo and expansion panel

### DIFF
--- a/en/components/combo_features.md
+++ b/en/components/combo_features.md
@@ -22,7 +22,7 @@ The following demo demonstrates some of the combo features that are enabled/disa
 <div class="divider--half"></div>
 
 ### Usage
-To get started with the Ignite UI for Angular Combo import the `IgxComboModule` in the **app.module.ts** file. For the following sample the [igx-switch](swtich.md) component is used and in addition we will need the `IgxSwitchModule` also:
+To get started with the Ignite UI for Angular Combo import the `IgxComboModule` in the **app.module.ts** file. For the following sample the [igx-switch](switch.md) component is used and in addition we will need the `IgxSwitchModule` also:
 
 ```typescript
 // app.module.ts

--- a/en/components/combo_features.md
+++ b/en/components/combo_features.md
@@ -22,7 +22,7 @@ The following demo demonstrates some of the combo features that are enabled/disa
 <div class="divider--half"></div>
 
 ### Usage
-To get started with the Ignite UI for Angular Combo import the `IgxComboModule` in the **app.module.ts** file. For the following sample the [igx-switch]({environment:angularApiUrl}/classes/igxswitchcomponent.html) component is used and in addition we will need the `IgxSwitchModule` also:
+To get started with the Ignite UI for Angular Combo import the `IgxComboModule` in the **app.module.ts** file. For the following sample the [igx-switch](swtich.md) component is used and in addition we will need the `IgxSwitchModule` also:
 
 ```typescript
 // app.module.ts
@@ -163,7 +163,7 @@ Defining a combo's groupKey option will group the items, according to the provid
 * [Template Driven Forms Integration](input_group.md)
 * [Reactive Forms Integration](input_group_reactive_forms.md)
 * [Cascading Scenario](combo_cascading.md)
-* [IgxSwitch]({environment:angularApiUrl}/classes/igxswitchcomponent.html)
+* [IgxSwitch](switch.md)
 
 Our community is active and always welcoming to new ideas.
 

--- a/en/components/expansion_panel.md
+++ b/en/components/expansion_panel.md
@@ -193,7 +193,7 @@ We can also override the default icon that is used in the control by passing con
 Our component will now render "Show More" when the panel is collapsed and "Collapse" once it's fully expanded.
 ### Adding content
 
-The [`igx-expansion-panel-body`]({environment:angularApiUrl}/classes/igxexpansionpanelbodycomponent.html) tag of the component accepts all kinds of markup and renders everything with the `ng-content` projection. We can use an [`IgxAvatar`]({environment:angularApiUrl}/classes/igxavatarcomponent.html) to freshen up our expansion panel's inner content:
+The [`igx-expansion-panel-body`]({environment:angularApiUrl}/classes/igxexpansionpanelbodycomponent.html) tag of the component accepts all kinds of markup and renders everything with the `ng-content` projection. We can use an [`IgxAvatar`](avatar.html) to freshen up our expansion panel's inner content:
 First, we need to import the `IgxAvatarModule` in our **app.module.ts**
 ```typescript
 // in app.module.ts
@@ -246,7 +246,7 @@ After applying all of the changes to our initial component, here is the final re
     <button data-localize="stackblitz" class="stackblitz-btn" data-iframe-id="expansion-sample-3-sample" data-demos-base-url="{environment:demosBaseUrl}">view on stackblitz</button>
 </div>
 
-The `IgxExpansionPanel` control allows all sort of content to be added inside of the `igx-expansion-panel-body`. It can render [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html)s, [`IgxCombo`]({environment:angularApiUrl}/classes/igxcombocomponent.html), charts and even other expansion panels!
+The `IgxExpansionPanel` control allows all sort of content to be added inside of the `igx-expansion-panel-body`. It can render [`IgxGrid`](grid/grid.md)s, [`IgxCombo`](combo.html), charts and even other expansion panels!
 
 ## Using Animations
 ### Using specific animation
@@ -522,7 +522,7 @@ You can see the results below:
 
 ## Weather Forecast Sample
 
-The following is an illustration of using the [`IgxExpansionPanelComponent`]({environment:angularApiUrl}/classes/igxexpansionpanelcomponent.html) in combination with several other components like [`IgxCard`]({environment:angularApiUrl}/classes/igxcardcomponent.html) and [`IgxIcon`]({environment:angularApiUrl}/classes/igxiconcomponent.html) to achieve a particular task. In this case - creating a weather component capable of showing both current day temperature and conditions as well as forecast details. If needed, the user can expand more and see the upcoming days weather conditions.
+The following is an illustration of using the [`IgxExpansionPanelComponent`]({environment:angularApiUrl}/classes/igxexpansionpanelcomponent.html) in combination with several other components like [`IgxCard`](card.html) and [`IgxIcon`](icon.html) to achieve a particular task. In this case - creating a weather component capable of showing both current day temperature and conditions as well as forecast details. If needed, the user can expand more and see the upcoming days weather conditions.
 
 ```typescript
 // in weather-forecast.component.ts

--- a/jp/components/combo_features.md
+++ b/jp/components/combo_features.md
@@ -23,7 +23,7 @@ Combo コントロールは、データと値のバインディング、カス�
 <div class="divider--half"></div>
 
 ### 使用方法
-Ignite UI for Angular Combo を使用する前に `IgxComboModule` を **app.module.ts** ファイルにインポートします。以下のサンプルは [igx-switch]({environment:angularApiUrl}/classes/igxswitchcomponent.html) を使用していますが、追加で `IgxSwitchModule` も必要です。
+Ignite UI for Angular Combo を使用する前に `IgxComboModule` を **app.module.ts** ファイルにインポートします。以下のサンプルは [igx-switch](switch.md) を使用していますが、追加で `IgxSwitchModule` も必要です。
 
 ```typescript
 // app.module.ts
@@ -164,7 +164,7 @@ export class MyExampleComponent {
 * [テンプレート駆動フォームの統合](input_group.md)
 * [リアクティブ フォームの統合](input_group_reactive_forms.md)
 * [カスケーディング](combo_cascading.md)
-* [IgxSwitch]({environment:angularApiUrl}/classes/igxswitchcomponent.html)
+* [IgxSwitch](switch.md)
 
 コミュニティに参加して新しいアイデアをご提案ください。
 

--- a/jp/components/expansion_panel.md
+++ b/jp/components/expansion_panel.md
@@ -194,7 +194,7 @@ export class ExpansionPanelComponent {
 このコンポーネントは、パネルの縮小時と完全に展開した後に「更に表示」を描画します。
 ### コンテキストの追加
 
-コンポーネントの [`igx-expansion-panel-body`]({environment:angularApiUrl}/classes/igxexpansionpanelbodycomponent.htm タグはすべてのマークアップを受け取り、`ng-content` プロジェクションですべてを描画します。[`IgxAvatar`]({environment:angularApiUrl}/classes/igxavatarcomponent.html) を使用して展開パネルのインナー コンテンツを更新できます。
+コンポーネントの [`igx-expansion-panel-body`]({environment:angularApiUrl}/classes/igxexpansionpanelbodycomponent.htm タグはすべてのマークアップを受け取り、`ng-content` プロジェクションですべてを描画します。[`IgxAvatar`](avatar.html) を使用して展開パネルのインナー コンテンツを更新できます。
 はじめに `IgxAvatarModule` を **app.module.ts** にインポートします。
 ```typescript
 // in app.module.ts
@@ -247,7 +247,7 @@ export class ExpansionPanelComponent {
     <button data-localize="stackblitz" class="stackblitz-btn" data-iframe-id="expansion-sample-3-sample" data-demos-base-url="{environment:demosBaseUrl}">view on stackblitz</button>
 </div>
 
-`IgxExpansionPanel` コントロールは、すべてのコンテンツの並べ替え[`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html)、[`IgxCombo`]({environment:angularApiUrl}/classes/igxcombocomponent.html)、チャート、更に他の展開パネルも描画できます。
+`IgxExpansionPanel` コントロールは、すべてのコンテンツの並べ替え[`IgxGrid`](grid/grid.html)、[`IgxCombo`](combo.html)、チャート、更に他の展開パネルも描画できます。
 
 ## アニメーションの使用
 ### 特定のアニメーションの使用
@@ -523,7 +523,7 @@ export class ExpansionPanelComponent {
 
 ## 天気予報のサンプル
 
-以下のサンプルは、[`IgxExpansionPanelComponent`]({environment:angularApiUrl}/classes/igxexpansionpanelcomponent.html) に加え、[`IgxCard`]({environment:angularApiUrl}/classes/igxcardcomponent.html) や [`IgxIcon`]({environment:angularApiUrl}/classes/igxiconcomponent.html) など、その他複数のコンポーネントを使用しています。ここでは、今日の気温や天気の状態、更に予報の詳細を表示する天気のコンポーネントを作成します。必要に応じてユーザーが更に展開でき、次の数日間の天気を表示できます。
+以下のサンプルは、[`IgxExpansionPanelComponent`]({environment:angularApiUrl}/classes/igxexpansionpanelcomponent.html) に加え、[`IgxCard`](card.html) や [`IgxIcon`](icon.html) など、その他複数のコンポーネントを使用しています。ここでは、今日の気温や天気の状態、更に予報の詳細を表示する天気のコンポーネントを作成します。必要に応じてユーザーが更に展開でき、次の数日間の天気を表示できます。
 
 ```typescript
 // in weather-forecast.component.ts

--- a/kr/components/combo_features.md
+++ b/kr/components/combo_features.md
@@ -23,7 +23,7 @@ The following demo demonstrates some of the combo features that are enabled/disa
 <div class="divider--half"></div>
 
 ### Usage
-To get started with the Ignite UI for Angular Combo import the `IgxComboModule` in the **app.module.ts** file. For the following sample the [igx-switch]({environment:angularApiUrl}/classes/igxswitchcomponent.html) component is used and in addition we will need the `IgxSwitchModule` also:
+To get started with the Ignite UI for Angular Combo import the `IgxComboModule` in the **app.module.ts** file. For the following sample the [igx-switch](switch.md) component is used and in addition we will need the `IgxSwitchModule` also:
 
 ```typescript
 // app.module.ts
@@ -164,7 +164,7 @@ Defining a combo's groupKey option will group the items, according to the provid
 * [Template Driven Forms Integration](input_group.md)
 * [Reactive Forms Integration](input_group_reactive_forms.md)
 * [Cascading Scenario](combo_cascading.md)
-* [IgxSwitch]({environment:angularApiUrl}/classes/igxswitchcomponent.html)
+* [IgxSwitch](switch.md)
 
 Our community is active and always welcoming to new ideas.
 

--- a/kr/components/expansion_panel.md
+++ b/kr/components/expansion_panel.md
@@ -194,7 +194,7 @@ We can also override the default icon that is used in the control by passing con
 Our component will now render "Show More" when the panel is collapsed and "Collapse" once it's fully expanded.
 ### Adding content
 
-The [`igx-expansion-panel-body`]({environment:angularApiUrl}/classes/igxexpansionpanelbodycomponent.html) tag of the component accepts all kinds of markup and renders everything with the `ng-content` projection. We can use an [`IgxAvatar`]({environment:angularApiUrl}/classes/igxavatarcomponent.html) to freshen up our expansion panel's inner content:
+The [`igx-expansion-panel-body`]({environment:angularApiUrl}/classes/igxexpansionpanelbodycomponent.html) tag of the component accepts all kinds of markup and renders everything with the `ng-content` projection. We can use an [`IgxAvatar`](avatar.html) to freshen up our expansion panel's inner content:
 First, we need to import the `IgxAvatarModule` in our **app.module.ts**
 ```typescript
 // in app.module.ts
@@ -247,7 +247,7 @@ After applying all of the changes to our initial component, here is the final re
     <button data-localize="stackblitz" class="stackblitz-btn" data-iframe-id="expansion-sample-3-sample" data-demos-base-url="{environment:demosBaseUrl}">StackBlitz 에서보기</button>
 </div>
 
-The `IgxExpansionPanel` control allows all sort of content to be added inside of the `igx-expansion-panel-body`. It can render [`IgxGrid`]({environment:angularApiUrl}/classes/igxgridcomponent.html)s, [`IgxCombo`]({environment:angularApiUrl}/classes/igxcombocomponent.html), charts and even other expansion panels!
+The `IgxExpansionPanel` control allows all sort of content to be added inside of the `igx-expansion-panel-body`. It can render [`IgxGrid`](grid/grid.html)s, [`IgxCombo`](combo.html), charts and even other expansion panels!
 
 ## Using Animations
 ### Using specific animation
@@ -523,7 +523,7 @@ You can see the results below:
 
 ## Weather Forecast Sample
 
-The following is an illustration of using the [`IgxExpansionPanelComponent`]({environment:angularApiUrl}/classes/igxexpansionpanelcomponent.html) in combination with several other components like [`IgxCard`]({environment:angularApiUrl}/classes/igxcardcomponent.html) and [`IgxIcon`]({environment:angularApiUrl}/classes/igxiconcomponent.html) to achieve a particular task. In this case - creating a weather component capable of showing both current day temperature and conditions as well as forecast details. If needed, the user can expand more and see the upcoming days weather conditions.
+The following is an illustration of using the [`IgxExpansionPanelComponent`]({environment:angularApiUrl}/classes/igxexpansionpanelcomponent.html) in combination with several other components like [`IgxCard`](card.html) and [`IgxIcon`](icon.html) to achieve a particular task. In this case - creating a weather component capable of showing both current day temperature and conditions as well as forecast details. If needed, the user can expand more and see the upcoming days weather conditions.
 
 ```typescript
 // in weather-forecast.component.ts


### PR DESCRIPTION
In a component's topic, when mentioning another component, there should be a link that leads to the mentioned component's topic.