### PR TITLE
Updating to 2.0.16 version of docfx-template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3122,9 +3122,9 @@
       }
     },
     "igniteui-docfx-template": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/igniteui-docfx-template/-/igniteui-docfx-template-2.0.15.tgz",
-      "integrity": "sha512-peGruTKPAtBzz5nC88OPT2dHmS6ZTohKG4g39Kwg9UvLDvsn1k8vCTl8ZaTH3Izelj7yYhTZyikjqgHlMpd5lw=="
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/igniteui-docfx-template/-/igniteui-docfx-template-2.0.16.tgz",
+      "integrity": "sha512-NxAk1fyD4t8NA8YybjYuPzspcLEPnnSng2OASfZTcs51HUnQXGlK5YHVShAE/0HHz/WiBcJ0KZ74xK5wwEy2RA=="
     },
     "immutable": {
       "version": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-file-include": "^2.0.1",
     "gulp-sass": "^4.0.1",
     "gulp-shell": "^0.6.5",
-    "igniteui-docfx-template": "2.0.15",
+    "igniteui-docfx-template": "^2.0.16",
     "natives": "^1.1.6",
     "yargs": "^10.0.3"
   }


### PR DESCRIPTION
This version contain fixes:
- StackBlitz live editing usage under EDGE https://github.com/IgniteUI/igniteui-docfx-template/issues/94
- Theme changing logic in EDGE and IE11 https://github.com/IgniteUI/igniteui-docfx-template/issues/92

It should be tested for both issues before merging.