### PR TITLE
docs(grid): Update in grid column resizing topic #

### DIFF
--- a/en/components/grids_templates/column_resizing.md
+++ b/en/components/grids_templates/column_resizing.md
@@ -137,9 +137,6 @@ You can also configure the minimum and maximum allowable column widths. This is 
 ```
 }
 
-> [!NOTE]
-> Resizing a column below **88px** is not possible, even when [`minWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#minwidth) is set to a value less than that.
-
 #### Auto-size columns on double click
 
 Each column can be **auto sized** by double clicking the right side of the header - the column will be sized to the longest currently visible cell value, including the header itself. This behavior is enabled by default, no additional configuration is needed. However, the column will not be auto-sized in case [`maxWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#maxwidth) is set on that column and the new width exceeds that [`maxWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#maxwidth) value. In this case the column will be sized according to preset [`maxWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#maxwidth) value.

--- a/jp/components/grids_templates/column_resizing.md
+++ b/jp/components/grids_templates/column_resizing.md
@@ -141,9 +141,6 @@ public onResize(event) {
 ```
 }
 
-> [!NOTE]
-> [`minWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#minwidth) が値より小さい値に設定されてた場合も、列を **88px** より小さいサイズに変更することはできません。
-
 #### ダブルクリックで列の自動サイズ調整
 
 各列ヘッダーの右側をダブルクリックして列を**自動サイズ調整**することができます。列は、現在表示されているヘッダーを含む一番長いセル値にサイズ設定されます。この動作はデフォルトで有効なため、追加で構成する必要はありません。ただし、[`maxWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#maxwidth) がその列に設定された際に新しい幅が [`maxWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#maxwidth) 値より大きい場合、列は自動サイズ調整されません。この場合、列が [`maxWidth`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#maxwidth) 値に設定されます。


### PR DESCRIPTION
Removed the note about 88px column resizing limitation