### PR TITLE
Fix minor issues in the new overlay position docs

### DIFF
--- a/en/components/overlay_position.md
+++ b/en/components/overlay_position.md
@@ -58,15 +58,15 @@ Then specify the position strategy to be used by the overlay. The position strat
 
 ### Creating position strategy with predefined position settings
 
-Each position strategy has its own position settings. This setting determines how the content will be shown. In the example bellow we are creating a new `PositionSettings` object. Using it we force the overlay to show the content starting from the top left point of the provided `target` - the `buttonElement`. The direction in which the content will be shown is set to top right. Then we create a new `ConnectedPositionStrategy` and pass in the `PositionSettings`.
+Each position strategy has its own position settings. This setting determines how the content will be shown. In the example bellow we are creating a new `PositionSettings` object. Using it we force the overlay to show the content starting from the top right point of the provided `target` - the `buttonElement`. The direction in which the content will be shown is set to top left. Then we create a new `ConnectedPositionStrategy` and pass in the `PositionSettings`.
 
 ```typescript
 const positionSettings: PositionSettings = {
     target: buttonElement.nativeElement,
-    horizontalDirection: HorizontalAlignment.Left,
-    verticalDirection: VerticalAlignment.Top,
     horizontalStartPoint: HorizontalAlignment.Right,
-    verticalStartPoint: VerticalAlignment.Top
+    verticalStartPoint: VerticalAlignment.Top,
+    horizontalDirection: HorizontalAlignment.Left,
+    verticalDirection: VerticalAlignment.Top
 };
 
 const strategy = new ConnectedPositioningStrategy(positionSettings);


### PR DESCRIPTION
The direction and start point in `Creating position strategy with predefined position settings` sections are different in text description and in the code. This changes the description to match what is in the code