### PR TITLE
Update to 2.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3241,9 +3241,9 @@
       }
     },
     "igniteui-docfx-template": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/igniteui-docfx-template/-/igniteui-docfx-template-2.7.4.tgz",
-      "integrity": "sha512-CSFZZ7peyiyaudP0LBC2hhdNIV6qa4ufeKfkfiEL1U9olLs009kias4dwi4ZAqnhuX2c8C3kDpcGEGk3H3b24A==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/igniteui-docfx-template/-/igniteui-docfx-template-2.7.6.tgz",
+      "integrity": "sha512-T22x5oRYDqNXgOqrzumQvlpM23bTQeiSUCrNDKkOcJHjqT3n2HqVSu4IMKBLRGXJ1CGjqlLn3fWZIoOgim9CkQ==",
       "requires": {
         "gulp-uglify-es": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "gulp-sass": "^4.0.1",
-    "igniteui-docfx-template": "2.7.4",
+    "igniteui-docfx-template": "2.7.6",
     "natives": "^1.1.6",
     "yargs": "^10.0.3"
   },


### PR DESCRIPTION
Update docfx-template to 2.7.6 in order to disable the non-working StackBlitz buttons