### PR TITLE
feat(update-guide): add section for input-group disabled property

### DIFF
--- a/en/components/general/update-guide.md
+++ b/en/components/general/update-guide.md
@@ -245,6 +245,25 @@ grid.getRowByIndex(0).expanded = false;
 * *ng update* will migrate most of the uses of *IgxGridRowComponent*, *IgxTreeGridRowComponent*, *IgxHierarchicalRowComponent*, *IgxGridGroupByRowComponent* , like imports, typings and casts. If a place in your code using any of the above is not migrated, just remove the typing/cast, or change it with [`RowType`]({environment:angularApiUrl}/interfaces/rowtype.html).
 * *getRowByIndex* will now return a [`RowType`]({environment:angularApiUrl}/interfaces/rowtype.html) object, if the row at that index is a summary row (previously used to returned *undefined*). *row.isSummaryRow* and *row.isGroupByRow* return true if the row at the index is a summary row or a group by row.
 
+### IgxInputGroupComponent
+* `disabled` property has been removed. The property was misleading, as the state of the input group was always managed by the underlying `igxInput`.
+* Running `ng update` will handle all instances in which `[disabled]` was used as an `@Input` in templates.
+* If you are referencing the property in a `.ts` file:
+```typescript
+export class CustomComponent {
+    public inputGroup: IgxInputGroupComponent
+    ...
+    this.inputGroup.disabled = false;
+}
+```
+please manually update your code to reference the underlying input directive's `disabled` property:
+```typescript
+export class CustomComponent {
+    public input: IgxInputDirective
+    ...
+    this.input.disabled = false;
+}
+```
 
 ## From 10.2.x to 11.0.x
 * IgxGrid, IgxTreeGrid, IgxHierarchicalGrid

--- a/en/components/general/update-guide.md
+++ b/en/components/general/update-guide.md
@@ -246,24 +246,25 @@ grid.getRowByIndex(0).expanded = false;
 * *getRowByIndex* will now return a [`RowType`]({environment:angularApiUrl}/interfaces/rowtype.html) object, if the row at that index is a summary row (previously used to returned *undefined*). *row.isSummaryRow* and *row.isGroupByRow* return true if the row at the index is a summary row or a group by row.
 
 ### IgxInputGroupComponent
-* `disabled` property has been removed. The property was misleading, as the state of the input group was always managed by the underlying `igxInput`.
-* Running `ng update` will handle all instances in which `[disabled]` was used as an `@Input` in templates.
-* If you are referencing the property in a `.ts` file:
-```typescript
-export class CustomComponent {
-    public inputGroup: IgxInputGroupComponent
-    ...
-    this.inputGroup.disabled = false;
-}
-```
-please manually update your code to reference the underlying input directive's `disabled` property:
-```typescript
-export class CustomComponent {
-    public input: IgxInputDirective
-    ...
-    this.input.disabled = false;
-}
-```
+* The `disabled` property has been removed. The property was misleading, as the state of the input group was always managed by the underlying `igxInput`.
+    * Running `ng update` will handle all instances in which `[disabled]` was used as an `@Input` in templates.
+    * If you are referencing the property in a `.ts` file:
+    ```typescript
+    export class CustomComponent {
+        public inputGroup: IgxInputGroupComponent
+        ...
+        this.inputGroup.disabled = false;
+    }
+    ```
+
+    you should please manually update your code to reference the underlying input directive's `disabled` property:
+    ```typescript
+    export class CustomComponent {
+        public input: IgxInputDirective
+        ...
+        this.input.disabled = false;
+    }
+    ```
 
 ## From 10.2.x to 11.0.x
 * IgxGrid, IgxTreeGrid, IgxHierarchicalGrid


### PR DESCRIPTION
Updating the `update-guide` to include a section about `IgxInputGroupComponent.disabled` manual migration.
Related to https://github.com/IgniteUI/igniteui-angular/issues/9339

### Checklist:
 
 - [ ] check topic's TOC/menu and paragraph headings
 - [ ] link to other topics using `../relative/path.md`
 - [ ] at the References section at the end of the topic add links to topics, samples, etc
 - [ ] reference API documentation instead of adding a section with API

<br />

 - [ ] use valid component names - [Data] Grid, `IgxSelectComponent`, `<igx-combo>`
 - [ ] use spell checker tool (VS Code, Grammarly, Microsoft Editor)
 - [ ] add inline `code blocks` for the names of classes / tags / properties
 - [ ] add language descriptor for the ```code blocks```
 - [ ] check broken links (use browser add-on)
 - [ ] check if sample is working and fully visible in the topic
 - [ ] check if sample is working and fully visible in the StackBlitz
 - [ ] check if code blocks match the code in StackBlitz demo

<br />

 - [ ] follow SEO guidelines to fill topic's metadata ([SEO guidelines](https://infragisticsinc297.sharepoint.com/:w:/g/Groups/marketing/EWz9InT4FDlErHCumxsKGY4Bd8H03yhRWxDFk47luRz-_Q?e=S5wWcx))

<br />

 - [ ] do not resolve requested changes (leave that to the reviewer)
 - [ ] add `pending-localization` label when the review of the PR is done
 - [ ] add a member from the localization team to translate it
