### PR TITLE
Chore(*): Fix broken links in grid templates

### DIFF
--- a/en/components/grids_templates/clipboard-interactions.md
+++ b/en/components/grids_templates/clipboard-interactions.md
@@ -82,7 +82,6 @@ We expose [`clipboardOptions`]({environment:angularApiUrl}/classes/igxgridcompon
 * [Filtering](filtering.md)
 * [Sorting](sorting.md)
 * [Summaries](summaries.md)
-* [Summaries](summaries.md)
 * [Column Pinning](column-pinning.md)
 * [Selection](selection.md)
 * [Virtualization and Performance](virtualization.md)

--- a/en/components/grids_templates/clipboard-interactions.md
+++ b/en/components/grids_templates/clipboard-interactions.md
@@ -1,13 +1,13 @@
 @@if (igxName === 'IgxGrid') {
 ---
-title: Angular Grid Clipboard Interactions - Ignite UI for Angular 
+title: Angular Grid Clipboard Interactions - Ignite UI for Angular 
 _description: The Angular Data Grid Clipboard functionality provides fast, easy and customizable way to copy, paste and export data to Excel or other programs. Try it now!
 _keywords: copy data, igniteui for angular, infragistics
 ---
 }
 @@if (igxName === 'IgxTreeGrid') {
 ---
-title: Angular TreeGrid Clipboard Interactions - Ignite UI for Angular 
+title: Angular TreeGrid Clipboard Interactions - Ignite UI for Angular 
 _description: The Angular TreeGrid Clipboard functionality provides fast, easy and customizable way to copy, paste and export data to Excel or other programs. Try it now!
 _keywords: copy data, igniteui for angular, infragistics
 _canonicalLink: grid/clipboard-interactions
@@ -63,7 +63,7 @@ Copy behavior is working with the default interaction defined by the browser and
 @@if (igxName === 'IgxGrid') { You can use a custom paste handler in order to configure `paste` behavior, have a look at our [Paste from Excel topic](paste-excel.md). }
 
 ## API Usage
-We expose [`clipboardOptions`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clipboardoptions) @Input property, which handles the following options:
+We expose [`clipboardOptions`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clipboardOptions) @Input property, which handles the following options:
 - [`enabled`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clipboardoptions.enabled) Enables/disables copying of selected cells.
 - [`copyHeaders`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clipboardoptions.copyHeaders) Include the associated headers when copying.
 - [`copyFormatters`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clipboardoptions.copyFormatters) Apply any existing column formatters to the copied data.
@@ -72,7 +72,7 @@ We expose [`clipboardOptions`]({environment:angularApiUrl}/classes/igxgridcompon
 > [!NOTE] 
 > Excel can automatically detect text that is separated by tabs (tab-delimited `/t`) and properly paste the data into separate columns. When the paste format doesn't work, and everything you paste appears in a single column, then Excel's delimiter is set to another character, or your text is using spaces instead of tabs.
 
-- [`gridCopy`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#gridCopy) Emitted when a copy operation is executed. Fired only if copy behavior is enabled through the [`clipboardOptions`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clipboardoptions)
+- [`gridCopy`]({environment:angularApiUrl}/classes/igxcolumncomponent.html#gridCopy) Emitted when a copy operation is executed. Fired only if copy behavior is enabled through the [`clipboardOptions`]({environment:angularApiUrl}/classes/igxgridcomponent.html#clipboardOptions)
 
 ## Additional Resources
 <div class="divider--half"></div>

--- a/en/components/grids_templates/column-moving.md
+++ b/en/components/grids_templates/column-moving.md
@@ -73,7 +73,7 @@ The @@igComponent component in Ignite UI for Angular provides the **Column Movin
 
 ## Overview
 
-**Column moving** feature is enabled on a per-grid level, meaning that the [**@@igSelector**]({environment:angularApiUrl}/classes/@@igTypeDoc.html) could have either movable or immovable columns. This is done via the [`moving`]({environment:angularApiUrl}/classes/igxgridcomponent.html#moving) input of the [`igx-grid`]({environment:angularApiUrl}/classes/igxgridncomponent.html).
+**Column moving** feature is enabled on a per-grid level, meaning that the [**@@igSelector**]({environment:angularApiUrl}/classes/@@igTypeDoc.html) could have either movable or immovable columns. This is done via the [`moving`]({environment:angularApiUrl}/classes/igxgridcomponent.html#moving) input of the [`igx-grid`]({environment:angularApiUrl}/classes/igxgridcomponent.html).
 
 
 @@if (igxName === 'IgxGrid') {
@@ -202,7 +202,7 @@ The last step is to **include** the component mixins with its respective theme:
 ```
 
 > [!NOTE]
-> Depending on the component [**View Encapsulation**](/components/themes/sass/component-themes.html#view-encapsulation) strategy, it may be necessary to `penetrate` this encapsulation using `::ng-deep`
+> Depending on the component [**View Encapsulation**](/products/ignite-ui-angular/angular/components/themes/sass/component-themes#view-encapsulation) strategy, it may be necessary to `penetrate` this encapsulation using `::ng-deep`
 
 ```scss
 :host {
@@ -238,11 +238,11 @@ $dark-grid-column-moving-theme: grid-theme(
 
 
 > [!NOTE]
-> Thecolor andpalette are powerful functions for generating and retrieving colors. Please refer to [`Palettes`](/components/themes/palettes.html) topic for detailed guidance on how to use them.
+> Thecolor andpalette are powerful functions for generating and retrieving colors. Please refer to [`Palettes`](/products/ignite-ui-angular/angular/components/themes/palettes) topic for detailed guidance on how to use them.
 
 ### Using Schemas
 
-Going further with the theming engine, you can build a robust and flexible structure that benefits from [schemas](/components/themes/sass/schemas.html). A **schema** is a recipe of a theme.
+Going further with the theming engine, you can build a robust and flexible structure that benefits from [schemas](/products/ignite-ui-angular/angular/components/themes/sass/schemas). A **schema** is a recipe of a theme.
 
 Extend one of the two predefined schemas, that are provided for every component, in this case - [light-grid]({environment:sassApiUrl}/index.html#variable-_light-grid).
 

--- a/en/components/grids_templates/column-moving.md
+++ b/en/components/grids_templates/column-moving.md
@@ -98,7 +98,7 @@ The @@igComponent component in Ignite UI for Angular provides the **Column Movin
 ## API
 In addition to the drag and drop functionality, the Column Moving feature also provides two API methods to allow moving a column/reordering columns programmatically: 
 
-[`moveColumn`]({environment:angularApiUrl}/classes/igxgridcomponent.html#movecolumn) - Moves a column before or after another column (a target). The first parameter is the column to be moved, and the second parameter is the target column. Also accepts an optional third parameter `position` (representing a [`DropPosition`]({environment:angularApiUrl}/enums/dropposition.html) value), which determines whether to place the column before or after the target column.
+[`moveColumn`]({environment:angularApiUrl}/classes/igxgridcomponent.html#moveColumn) - Moves a column before or after another column (a target). The first parameter is the column to be moved, and the second parameter is the target column. Also accepts an optional third parameter `position` (representing a [`DropPosition`]({environment:angularApiUrl}/enums/dropposition.html) value), which determines whether to place the column before or after the target column.
 
 ```typescript
 // Move the ID column after the Name column


### PR DESCRIPTION
Fix broken links in moving columns doc and remove extra `Summary` link in `Additional resources` section in `clipboard-interaction.md`. #2931