### PR TITLE
fix(date-time-editor): displaying the table properly

### DIFF
--- a/en/components/date-time-editor.md
+++ b/en/components/date-time-editor.md
@@ -136,8 +136,9 @@ To set a specific input format, pass it as a string to the IgxDateTimeEditor dir
 ```
 
 The table bellow shows formats that are supported by the directive's [`inputFormat`]({environment:angularApiUrl}/classes/igxdatetimeeditordirective.html#inputFormat):
-| Format | Description |
-|:-------:|:-----------|
+
+|  Format  | Description |
+| -------- | ----------- |
 | `d` | Date, will be coerced with a leading zero while editing. |
 | `dd` | Date with an explicitly set leading zero. |
 | `M` | Month, will be coerced with a leading zero while editing. |


### PR DESCRIPTION
Closes #3740 

Note: Тhe [table](https://www.infragistics.com/products/ignite-ui-angular/angular/components/themes/typography#overview) in typographers topic is actually displayed correctly. A fix was needed only for the [table](https://www.infragistics.com/products/ignite-ui-angular/angular/components/date-time-editor#display-and-input-format) in the date-time-editor topic.

### Checklist:
 
 - [ ] check topic's TOC/menu and paragraph headings
 - [ ] link to other topics using `../relative/path.md`
 - [ ] at the References section at the end of the topic add links to topics, samples, etc
 - [ ] reference API documentation instead of adding a section with API

<br />

 - [ ] use valid component names - [Data] Grid, `IgxSelectComponent`, `<igx-combo>`
 - [x] use spell checker tool (VS Code, Grammarly, Microsoft Editor)
 - [ ] add inline `code blocks` for the names of classes / tags / properties
 - [ ] add language descriptor for the ```code blocks```
 - [ ] check broken links (use browser add-on)
 - [ ] check if sample is working and fully visible in the topic
 - [ ] check if sample is working and fully visible in the StackBlitz
 - [ ] check if code blocks match the code in StackBlitz demo

<br />

 - [ ] follow SEO guidelines to fill topic's metadata ([SEO guidelines](https://infragisticsinc297.sharepoint.com/:w:/g/Groups/marketing/EWz9InT4FDlErHCumxsKGY4Bd8H03yhRWxDFk47luRz-_Q?e=S5wWcx))

<br />

 - [ ] do not resolve requested changes (leave that to the reviewer)
 - [ ] add `pending-localization` label when the review of the PR is done
 - [ ] add a member from the localization team to translate it
