### PR TITLE
chore: remove standalone preview flag from toc

### DIFF
--- a/en/components/toc.yml
+++ b/en/components/toc.yml
@@ -46,7 +46,6 @@
       new: true
     - name: Use Standalone Components
       href: general/how-to/how-to-use-standalone-components.md
-      preview: true
 - name: Angular Schematics & Ignite UI CLI
   href: general/cli-overview.md
   sortable: false

--- a/jp/components/toc.yml
+++ b/jp/components/toc.yml
@@ -47,7 +47,6 @@
       new: true
     - name: スタンドアロン コンポーネントの使用方法
       href: general/how-to/how-to-use-standalone-components.md
-      preview: true
 - name: Angular Schematics & Ignite UI CLI
   href: general/cli-overview.md
   sortable: false


### PR DESCRIPTION
It's not preview anymore, though I think ALL of the flags are outdated at this point and need to be reviewed

### Checklist:
 
 - [ ] check topic's TOC/menu and paragraph headings
 - [ ] link to other topics using `../relative/path.md`
 - [ ] at the References section at the end of the topic add links to topics, samples, etc
 - [ ] reference API documentation instead of adding a section with API

<br />

 - [ ] use valid component names - [Data] Grid, `IgxSelectComponent`, `<igx-combo>`
 - [ ] use spell checker tool (VS Code, Grammarly, Microsoft Editor)
 - [ ] add inline `code blocks` for the names of classes / tags / properties
 - [ ] add language descriptor for the ```code blocks```
 - [ ] check broken links (use browser add-on)
 - [ ] check if sample is working and fully visible in the topic
 - [ ] check if sample is working and fully visible in the StackBlitz
 - [ ] check if code blocks match the code in StackBlitz demo

<br />

 - [ ] follow SEO guidelines to fill topic's metadata ([SEO guidelines](https://infragisticsinc297.sharepoint.com/:w:/g/Groups/marketing/EWz9InT4FDlErHCumxsKGY4Bd8H03yhRWxDFk47luRz-_Q?e=S5wWcx))

<br />

 - [ ] do not resolve requested changes (leave that to the reviewer)
 - [ ] add `pending-localization` label when the review of the PR is done
 - [ ] add a member from the localization team to translate it
