### PR TITLE
docs(action-strip): update note with v20 change

### DIFF
--- a/en/components/action-strip.md
+++ b/en/components/action-strip.md
@@ -90,7 +90,7 @@ To initialize and position the Action Strip correctly, it needs to be inside a r
 </div>
 ```
 
-By default, the Action Strip will be visible, but this can be configured via the [`hidden`]({environment:angularApiUrl}/classes/igxactionstripcomponent.html#hidden) @Input property.
+By default, the Action Strip will not be visible, but this can be configured via the [`hidden`]({environment:angularApiUrl}/classes/igxactionstripcomponent.html#hidden) @Input property.
 
 ### Menu look and feel
 


### PR DESCRIPTION
All the snippets already weren't setting `hidden=true`, even though the samples code did, so those match the new behavior 😆 

### Checklist:
 
 - [ ] check topic's TOC/menu and paragraph headings
 - [ ] [Include TOC topic labels](https://github.com/IgniteUI/igniteui-docfx/blob/master/README.md#include-toc-topic-labels) in topic content has a valuable update, it's new or considered as `preview`\ `beta`
 - [ ] link to other topics using `../relative/path.md`
 - [ ] at the References section at the end of the topic add links to topics, samples, etc
 - [ ] reference API documentation instead of adding a section with API

<br />

 - [ ] use valid component names - [Data] Grid, `IgxSelectComponent`, `<igx-combo>`
 - [ ] use spell checker tool (VS Code, Grammarly, Microsoft Editor)
 - [ ] add inline `code blocks` for the names of classes / tags / properties
 - [ ] add language descriptor for the ```code blocks```
 - [ ] check broken links (use browser add-on)
 - [ ] check if sample is working and fully visible in the topic
 - [ ] check if sample is working and fully visible in the StackBlitz
 - [ ] check if code blocks match the code in StackBlitz demo

<br />

 - [ ] follow SEO guidelines to fill topic's metadata ([SEO guidelines](https://infragisticsinc297.sharepoint.com/:w:/g/Groups/marketing/EWz9InT4FDlErHCumxsKGY4Bd8H03yhRWxDFk47luRz-_Q?e=S5wWcx))

<br />

 - [ ] do not resolve requested changes (leave that to the reviewer)
 - [ ] add `pending-localization` label when the review of the PR is done
 - [ ] add a member from the localization team to translate it
