### PR TITLE
AI Skills - update code snippets and remove duplicated text

### DIFF
--- a/en/components/ai/skills.md
+++ b/en/components/ai/skills.md
@@ -112,8 +112,6 @@ Alternatively, one can use a general Agent Skills config so your Agent can easil
 
 3. The Agent will now discover these skills and load the relevant one automatically based on the context of your request.
 
-> **Tip for VS Code:** VS Code searches for skills in `.github/skills/`, `.claude/skills/`, and `.agents/skills/` by default. You can configure additional locations using the `chat.agentSkillsLocations` setting.
-
 > **Tip:** VS Code searches for skills in `.github/skills/`, `.claude/skills/`, and `.agents/skills/` by default. You can configure additional locations using the `chat.agentSkillsLocations` setting.
 
 ---
@@ -183,7 +181,7 @@ cp -r node_modules/igniteui-angular/skills/. .agents/skills/
 
 ```powershell
 # Windows (PowerShell)
-Copy-Item -Recurse node_modules\igniteui-angular\skills\* .agents\skills\
+Copy-Item -Recurse node_modules\igniteui-angular\skills .agents\skills
 ```
 
 Or copy individual skill directories as needed:
@@ -199,9 +197,9 @@ cp -r node_modules/igniteui-angular/skills/igniteui-angular-theming .agents/skil
 **Windows (PowerShell)**
 
 ```powershell
-Copy-Item -Recurse node_modules\igniteui-angular\skills\igniteui-angular-components .agents\skills\
-Copy-Item -Recurse node_modules\igniteui-angular\skills\igniteui-angular-grids .agents\skills\
-Copy-Item -Recurse node_modules\igniteui-angular\skills\igniteui-angular-theming .agents\skills\
+Copy-Item -Recurse node_modules\igniteui-angular\skills\igniteui-angular-components .agents\skills\igniteui-angular-components
+Copy-Item -Recurse node_modules\igniteui-angular\skills\igniteui-angular-grids .agents\skills\igniteui-angular-grids
+Copy-Item -Recurse node_modules\igniteui-angular\skills\igniteui-angular-theming .agents\skills\igniteui-angular-theming
 ```
 
 **Windows (Command Prompt)**


### PR DESCRIPTION
Multiple PowerShell `Copy-Item -Recurse` commands in Option C were producing incorrect directory structures, and a duplicate Tip block was present.

- **Bulk copy command**: Changed from `Copy-Item -Recurse node_modules\igniteui-angular\skills\* .agents\skills\` to `Copy-Item -Recurse node_modules\igniteui-angular\skills .agents\skills` — the `*` wildcard with `-Recurse` was flattening the directory structure instead of preserving subdirectories
- **Individual copy commands**: Added explicit destination folder names to all three `Copy-Item` commands (e.g. `.agents\skills\` → `.agents\skills\igniteui-angular-components`)
- **Duplicate Tip block**: Removed a duplicate "Tip for VS Code" that was identical to the "Tip" block immediately below it

All code snippets now produce the expected directory structure:

```
.agents\
  skills\
    igniteui-angular-components\
    igniteui-angular-grids\
    igniteui-angular-theming\
```